### PR TITLE
Updated conditionals to handle `0` values (Fixes #5)

### DIFF
--- a/main.js
+++ b/main.js
@@ -478,13 +478,13 @@ function SendMIDI_Note(messageType, midiPort, channel, note, velocity, callback)
 			callback({result: 'could-not-open-midi-out'});
 		})
 		.and(function() {
-			if (!channel) {
+			if (!Number.isInteger(channel)) {
 			channel = 0;
 			}
-			if (!note) {
+			if (!Number.isInteger(note)) {
 				note = 21;
 			}
-			if (!velocity) {
+			if (!Number.isInteger(velocity)) {
 				if (messageType === 'on') {
 					velocity = 127;
 				}
@@ -550,13 +550,13 @@ function SendMIDI_Aftertouch(midiPort, channel, note, value, callback) {
 			callback({result: 'could-not-open-midi-out'});
 		})
 		.and(function() {
-			if (!channel) {
+			if (!Number.isInteger(channel)) {
 				channel = 0;
 			}
-			if (!note) {
+			if (!Number.isInteger(note)) {
 				note = 21;
 			}
-			if (!value) {
+			if (!Number.isInteger(value)) {
 				value = 1;
 			}
 
@@ -592,13 +592,13 @@ function SendMIDI_CC(midiPort, channel, controller, value, callback) {
 			callback({result: 'could-not-open-midi-out'});
 		})
 		.and(function() {
-			if (!channel) {
+			if (!Number.isInteger(channel)) {
 				channel = 0;
 			}
-			if (!controller) {
+			if (!Number.isInteger(controller)) {
 				controller = 0;
 			}
-			if (!value) {
+			if (!Number.isInteger(value)) {
 				value = 1;
 			}
 
@@ -634,10 +634,10 @@ function SendMIDI_PC(midiPort, channel, value, callback) {
 			callback({result: 'could-not-open-midi-out'});
 		})
 		.and(function() {
-			if (!channel) {
+			if (!Number.isInteger(channel)) {
 				channel = 0;
 			}
-			if (!value) {
+			if (!Number.isInteger(value)) {
 				value = 1;
 			}
 
@@ -673,10 +673,10 @@ function SendMIDI_Pressure(midiPort, channel, value, callback) {
 			callback({result: 'could-not-open-midi-out'});
 		})
 		.and(function() {
-			if (!channel) {
+			if (!Number.isInteger(channel)) {
 				channel = 0;
 			}
-			if (!value) {
+			if (!Number.isInteger(value)) {
 				value = 1;
 			}
 
@@ -712,10 +712,10 @@ function SendMIDI_PitchBend(midiPort, channel, value, callback) {
 			callback({result: 'could-not-open-midi-out'});
 		})
 		.and(function() {
-			if (!channel) {
+			if (!Number.isInteger(channel)) {
 				channel = 0;
 			}
-			if (!value) {
+			if (!Number.isInteger(value)) {
 				value = 1;
 			}
 

--- a/views/settings.html
+++ b/views/settings.html
@@ -77,6 +77,7 @@
 			var MIDI_INPUTS = [];
 			
 			var MIDI_NOTES = [
+				{id: 0, label: '0 - unassigned'},
 				{id: 1, label: '1 - unassigned'},
 				{id: 2, label: '2 - unassigned'},
 				{id: 3, label: '3 - unassigned'},


### PR DESCRIPTION
### Proposed Changes

Fixes: #5 

This PR fixes a bug where `0` values caused some conditionals to unexpectedly evaluate to `true` since `0` is "falsy" in javascript. There were several other places besides just midi notes where `0` values could potentially cause a problem, so I went ahead and updated those conditionals as well.

*Note: A few of these weren't technically necessary since it was assigning a default of `0` anyway, but I decided to rewrite them all so a future change to a default value wouldn't cause unexpected issues.*