### PR TITLE
Process triggers for outgoing midi

### DIFF
--- a/main.js
+++ b/main.js
@@ -93,6 +93,7 @@ function initialRESTSetup() {
 		}
 		
 		SendMIDI(midiObj, sendResult);
+		processMIDI(midiObj);
 	});
 	
 	restServer.get('/sendmidi', function (req, res) {
@@ -104,6 +105,7 @@ function initialRESTSetup() {
 		}
 		
 		SendMIDI(midiObj, sendResult);
+		processMIDI(midiObj);
 	});
 	
 	restServer.post('/openport', function (req, res) {


### PR DESCRIPTION
My use case involves midi-relay bridging between ProPresenter and Companion but also has triggers for lighting and Spotify control.  I'd like both ProPresenter and Companion to have access to the lighting/Spotify and I found Companion's shell script option to be lacking reliability for applescripts.