### PR TITLE
jQuery loading fix, and CI improvements

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,41 @@
+name: Build Binaries
+on:
+  push: { branches: ["*"] }
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: Build (pkg)
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+        cache: npm
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: 🔨 Build Binaries
+      run: npm run build
+
+    - name: Upload Linux binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: midi-relay-linux
+        path: build/midi-relay-linux
+
+    - name: Upload MacOS binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: midi-relay-macos
+        path: build/midi-relay-macos
+
+    - name: Upload Windows binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: midi-relay-win
+        path: build/midi-relay-win.exe

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+        cache: npm
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: 🔨 Build Binaries
+      run: npm run build
+
+    - name: Create Github Release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "build/*"
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/build

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ const midi_trigger_file = './midi_triggers.json'; //local storage JSON file
 //other variables
 var clc = require('cli-color'); //console output text coloring
 var _ = require('lodash');
-const {version} = require('./package.json');
+const { version } = require('./package.json');
 const exec = require('child_process').exec;
 const figlet = require('figlet');
 const cors = require('cors');
@@ -48,22 +48,22 @@ function setUpApp() {
 }
 
 function initialRESTSetup() {
- 	// starts the Express server that will listen for incoming requests to send/receive MIDI commands and objects
- 	restServer = express();
+	// starts the Express server that will listen for incoming requests to send/receive MIDI commands and objects
+	restServer = express();
 	restServer.use(cors());
- 	restServer.use(bodyParser.json({ type: 'application/json' }));
+	restServer.use(bodyParser.json({ type: 'application/json' }));
 
 
 	//about the author, this program, etc.
 	restServer.get('/', function (req, res) {
 		res.sendFile('views/index.html', { root: __dirname });
 	});
-	
+
 	//settings page - view ports, create triggers, etc.
 	restServer.get('/settings', function (req, res) {
 		res.sendFile('views/settings.html', { root: __dirname });
 	});
-	
+
 	restServer.get('/midi_inputs', function (req, res) {
 		//gets all MIDI input ports
 		res.send(MIDI_inputs);
@@ -73,12 +73,12 @@ function initialRESTSetup() {
 		//gets all MIDI output ports
 		res.send(MIDI_outputs);
 	});
-	
+
 	restServer.get('/refresh', function (req, res) {
 		//refresh available ports
 		res.send(RefreshPorts());
 	});
-	
+
 	restServer.get('/version', function (req, res) {
 		//gets the version of the software
 		res.send(version);
@@ -87,54 +87,54 @@ function initialRESTSetup() {
 	restServer.post('/sendmidi', function (req, res) {
 		//sends MIDI using the provided JSON object in the POST body
 		let midiObj = req.body;
-		
+
 		function sendResult(json) {
 			res.send(json);
 		}
-		
+
 		SendMIDI(midiObj, sendResult);
 	});
-	
+
 	restServer.get('/sendmidi', function (req, res) {
 		//sends MIDI using the provided information in the querystring
 		let midiObj = req.query;
-		
+
 		function sendResult(json) {
 			res.send(json);
 		}
-		
+
 		SendMIDI(midiObj, sendResult);
 	});
-	
+
 	restServer.post('/openport', function (req, res) {
 		//opens the MIDI port to listen to using the provided JSON object in the POST body
-		
+
 		let midiObj = req.body;
 
-		if (midiObj.midiport) {			
+		if (midiObj.midiport) {
 			console.log(clc.cyan.bold('Attempting to open MIDI port: ' + midiObj.midiport));
 			for (let i = 0; i < MIDI_inputs.length; i++) {
 				if (MIDI_inputs[i].name === midiObj.midiport) {
 					if (!MIDI_inputs[i].opened) {
 						navigator().openMidiIn(midiObj.midiport)
-						.or(function () {
-							console.log(clc.red.bold('Cannot open port.'));
-							res.send({result: 'midiin-port-cannot-be-opened'});
-						})
-						.and(function() {
-							for (let i = 0; i < MIDI_inputs.length; i++) {
-								if (MIDI_inputs[i].name === this.name()) {
-									MIDI_inputs[i].opened = true;
-									break;
+							.or(function () {
+								console.log(clc.red.bold('Cannot open port.'));
+								res.send({ result: 'midiin-port-cannot-be-opened' });
+							})
+							.and(function () {
+								for (let i = 0; i < MIDI_inputs.length; i++) {
+									if (MIDI_inputs[i].name === this.name()) {
+										MIDI_inputs[i].opened = true;
+										break;
+									}
 								}
-							}
-							console.log(clc.green.bold('Port opened successfully: ' + midiObj.midiport));
-							this.connect(receiveMIDI.bind({'midiport': midiObj.midiport}));
-							res.send({result: 'midiin-port-opened', name: midiObj.midiport});
-						});
+								console.log(clc.green.bold('Port opened successfully: ' + midiObj.midiport));
+								this.connect(receiveMIDI.bind({ 'midiport': midiObj.midiport }));
+								res.send({ result: 'midiin-port-opened', name: midiObj.midiport });
+							});
 					}
 					else {
-						res.send({result: 'midiin-port-already-opened', name: midiObj.midiport});
+						res.send({ result: 'midiin-port-already-opened', name: midiObj.midiport });
 					}
 				}
 			}
@@ -143,41 +143,41 @@ function initialRESTSetup() {
 
 	restServer.post('/closeport', function (req, res) {
 		//closes the MIDI port to listen to using the provided JSON object in the POST body
-		
+
 		let midiObj = req.body;
 		res.send(ClosePort(midiObj));
 	});
-	
+
 	restServer.get('/triggers', function (req, res) {
 		//gets all triggers
-		
-		res.send(Triggers);		
+
+		res.send(Triggers);
 	});
-	
+
 	restServer.post('/addtrigger', function (req, res) {
 		//adds the trigger object to the list of triggers
 		let triggerObj = req.body;
-		
+
 		let result = AddTrigger(triggerObj);
-		res.send({result: result});
+		res.send({ result: result });
 	});
 
 	restServer.post('/edittrigger', function (req, res) {
 		//adds the trigger object to the list of triggers
 		let triggerObj = req.body;
-		
+
 		let result = EditTrigger(triggerObj);
-		res.send({result: result});
+		res.send({ result: result });
 	});
-	
+
 	restServer.get('/deletetrigger/:triggerid', function (req, res) {
 		//deletes the trigger
 		let triggerID = req.params.triggerid;
-		
+
 		let result = DeleteTrigger(triggerID);
-		res.send({result: result});
+		res.send({ result: result });
 	});
-	
+
 	restServer.get('/hosts', function (req, res) {
 		//returns list of other midi-relay servers on the network
 		res.send(mdns_hosts);
@@ -187,26 +187,26 @@ function initialRESTSetup() {
 	restServer.use(express.static(path.join(__dirname, 'views/static')));
 
 	//serve up jQuery from the Node module
-	restServer.use('/js/jquery', express.static(path.join(__dirname, 'node_modules/jquery/dist')));
+	restServer.use('/js/jquery', express.static(path.join(__dirname, 'node_modules', 'jquery', 'dist')));
 
 	restServer.use(function (req, res) {
-		res.status(404).send({error: true, url: req.originalUrl + ' not found.'});
+		res.status(404).send({ error: true, url: req.originalUrl + ' not found.' });
 	});
-	
+
 	restServer.listen(listenPort);
 	console.log(clc.blue.bold('MIDI Relay server started on: ' + listenPort));
 }
 
 function initialMDNSSetup() {
 	mdns_service = mdns.createAdvertisement(mdns.tcp('midi-relay'), listenPort, {
-		name:'midi-relay',
-		txt:{
-			txtvers:version
+		name: 'midi-relay',
+		txt: {
+			txtvers: version
 		}
 	});
-	
+
 	mdns_service.start();
-	
+
 	mdns_browser = mdns.createBrowser(mdns.tcp('midi-relay'));
 
 	mdns_browser.on('ready', function onReady() {
@@ -217,7 +217,7 @@ function initialMDNSSetup() {
 		for (let i = 0; i < data.type.length; i++) {
 			if (data.type[i].name === 'midi-relay') {
 				MDNS_AddHost(data.host, data.addresses[0], data.port);
-			}	
+			}
 		}
 	});
 }
@@ -257,7 +257,7 @@ function loadMIDITriggers() {
 	try {
 		console.log(clc.bold('Loading stored Triggers from file...'));
 		let rawdata = fs.readFileSync(midi_trigger_file);
-		let myJson = JSON.parse(rawdata); 
+		let myJson = JSON.parse(rawdata);
 
 		if (myJson.Triggers) {
 			Triggers = myJson.Triggers;
@@ -266,7 +266,7 @@ function loadMIDITriggers() {
 		else {
 			Triggers = [];
 			console.log(clc.red.bold('No stored triggers found.'));
-		}	
+		}
 	}
 	catch (error) {
 		console.log(clc.red.bold('Triggers could not be loaded due to an error:'));
@@ -277,9 +277,9 @@ function loadMIDITriggers() {
 			console.log(error);
 		}
 	}
-	
+
 	for (let i = 0; i < Triggers.length; i++) {
-		let port = MIDI_inputs.find( ({ name }) => name === Triggers[i].midiport);
+		let port = MIDI_inputs.find(({ name }) => name === Triggers[i].midiport);
 
 		if (port) {
 			if (port.opened) {
@@ -289,19 +289,19 @@ function loadMIDITriggers() {
 				console.log(clc.cyan.bold('Attempting to open MIDI port used in a Trigger: ' + Triggers[i].midiport));
 
 				navigator().openMidiIn(Triggers[i].midiport)
-				.or(function () {
-					console.log(clc.red.bold('Cannot open port.'));
-				})
-				.and(function() {
-					for (let j = 0; j < MIDI_inputs.length; j++) {
-						if (MIDI_inputs[j].name === this.name()) {
-							MIDI_inputs[j].opened = true;
-							break;
+					.or(function () {
+						console.log(clc.red.bold('Cannot open port.'));
+					})
+					.and(function () {
+						for (let j = 0; j < MIDI_inputs.length; j++) {
+							if (MIDI_inputs[j].name === this.name()) {
+								MIDI_inputs[j].opened = true;
+								break;
+							}
 						}
-					}
-					console.log(clc.green.bold('Port opened successfully: ' + Triggers[i].midiport));
-					this.connect(receiveMIDI.bind({'midiport': Triggers[i].midiport}));
-				});
+						console.log(clc.green.bold('Port opened successfully: ' + Triggers[i].midiport));
+						this.connect(receiveMIDI.bind({ 'midiport': Triggers[i].midiport }));
+					});
 				break;
 			}
 		}
@@ -315,19 +315,17 @@ function saveMIDITriggers() {
 	try {
 		console.log(clc.bold('Saving MIDI Triggers to file...'));
 		var myJson = {
-			Triggers: Triggers 
+			Triggers: Triggers
 		};
 
-		fs.writeFileSync(midi_trigger_file, JSON.stringify(myJson, null, 1), 'utf8', function(error) {
-			if (error)
-			{ 
+		fs.writeFileSync(midi_trigger_file, JSON.stringify(myJson, null, 1), 'utf8', function (error) {
+			if (error) {
 				console.log(clc.red.bold('Error saving MIDI triggers to file: ' + error));
 			}
-			else
-			{
+			else {
 				console.log(clc.green.bold('MIDI Triggers saved to file.'));
 			}
-		});	
+		});
 	}
 	catch (error) {
 		console.log(clc.red.bold('Error saving MIDI triggers to file: ' + error));
@@ -335,31 +333,31 @@ function saveMIDITriggers() {
 }
 
 function GetPorts() {
-	navigator.requestMIDIAccess().then(function(webmidi) {
+	navigator.requestMIDIAccess().then(function (webmidi) {
 		console.log(clc.magentaBright.bold('MIDI Output Ports'));
-		webmidi.outputs.forEach(function(port) { console.log(clc.magenta(port.name)); });
+		webmidi.outputs.forEach(function (port) { console.log(clc.magenta(port.name)); });
 		console.log(clc.cyanBright.bold('MIDI Input Ports'));
-		webmidi.inputs.forEach(function(port) { console.log(clc.cyan(port.name)); });
+		webmidi.inputs.forEach(function (port) { console.log(clc.cyan(port.name)); });
 		let info = navigator.info();
-		
+
 		MIDI_outputs = info.outputs;
-		
+
 		//retain the 'opened' property when reloading the array
 		let temp_inputs = info.inputs;
 		for (let i = 0; i < temp_inputs.length; i++) {
-			let port = MIDI_inputs.find( ({ name }) => name === temp_inputs[i].name);
+			let port = MIDI_inputs.find(({ name }) => name === temp_inputs[i].name);
 			if (port) {
 				if (port.opened) {
 					temp_inputs[i].opened = port.opened;
 				}
 			}
 		}
-		
+
 		MIDI_inputs = temp_inputs;
-		
+
 		loadMIDITriggers();
-		
-	}, function(err) {
+
+	}, function (err) {
 		if (err) {
 			console.log(clc.red.bold(err));
 			throw new Error(err);
@@ -371,16 +369,16 @@ function RefreshPorts() {
 	try {
 		navigator().refresh();
 		GetPorts();
-		return {result: 'ports-refreshed-successfully'};
+		return { result: 'ports-refreshed-successfully' };
 	}
-	catch(error) {
-		return {result: 'error', error: error};		
+	catch (error) {
+		return { result: 'error', error: error };
 	}
 }
 
 function ClosePort(midiObj) {
 	let found = false;
-	
+
 	if (midiObj.midiport) {
 		let portName = midiObj.midiport;
 		console.log(clc.cyan.bold('Attempting to close MIDI port: ' + portName));
@@ -395,16 +393,16 @@ function ClosePort(midiObj) {
 
 		if (found) {
 			console.log(clc.green.bold('Port closed successfully: ' + portName));
-			return {result: 'midiin-port-closed', name: portName};
+			return { result: 'midiin-port-closed', name: portName };
 		}
 		else {
 			console.log(clc.red.bold('Cannot close port.'));
-			return {result: 'midiin-port-cannot-be-closed'};
+			return { result: 'midiin-port-cannot-be-closed' };
 		}
 	}
 }
 
-function SendMIDI(midiObj, callback) {		
+function SendMIDI(midiObj, callback) {
 	if (midiObj.midiport) {
 		let index = null;
 
@@ -415,13 +413,12 @@ function SendMIDI(midiObj, callback) {
 		});
 
 		if (index === null) {
-			callback({result: 'invalid-midi-port'});
+			callback({ result: 'invalid-midi-port' });
 		}
 		else {
 			if (midiObj.midicommand) {
 				if (IncomingMIDIRelayTypes.includes(midiObj.midicommand)) {
-					switch(midiObj.midicommand)
-					{
+					switch (midiObj.midicommand) {
 						case 'noteon':
 							SendMIDI_Note('on', midiObj.midiport, parseInt(midiObj.channel), parseInt(midiObj.note), parseInt(midiObj.velocity), callback);
 							break;
@@ -450,27 +447,27 @@ function SendMIDI(midiObj, callback) {
 							SendMIDI_SysEx(midiObj.midiport, midiObj.message, callback);
 							break;
 						default:
-							callback({result: 'invalid-midi-command'});
+							callback({ result: 'invalid-midi-command' });
 							break;
-					}	
+					}
 				}
 				else {
-					callback({result: 'invalid-midi-command'});
+					callback({ result: 'invalid-midi-command' });
 				}
 			}
 			else {
-				callback({result: 'invalid-midi-command'});
-			}		
+				callback({ result: 'invalid-midi-command' });
+			}
 		}
 	}
 	else {
-		callback({result: 'invalid-midi-port'});
+		callback({ result: 'invalid-midi-port' });
 	}
 }
 
 function SendMIDI_Note(messageType, midiPort, channel, note, velocity, callback) {
 	try {
-		switch(messageType) {
+		switch (messageType) {
 			case 'on':
 				console.log(clc.magenta.bold('Sending Note On to Port: ') + midiPort);
 				break;
@@ -480,321 +477,321 @@ function SendMIDI_Note(messageType, midiPort, channel, note, velocity, callback)
 			default:
 				break;
 		}
-		
-		
-		let port = navigator().openMidiOut(midiPort)
-		.or(function() {
-			callback({result: 'could-not-open-midi-out'});
-		})
-		.and(function() {
-			if (!Number.isInteger(channel)) {
-			channel = 0;
-			}
-			if (!Number.isInteger(note)) {
-				note = 21;
-			}
-			if (!Number.isInteger(velocity)) {
-				if (messageType === 'on') {
-					velocity = 127;
-				}
-				else {
-					velocity = 0;
-				}
-			}
 
-			let midiObj = {channel: channel, note: note, velocity: velocity};
-			console.log(midiObj);
-			
-			let msg = null;
-			
-			let returnObj;
-			
-			let rawmessage = '';
-			
-			switch(messageType) {
-				case 'on':
-					msg = navigator.MIDI.noteOn(channel, note, velocity);
-					this.send(msg).close();
-					console.log(clc.magenta.bold('Note On Sent.'));
-					for (let i = 0; i < msg.length; i++) {
-						rawmessage += msg[i];
-						if (i < (msg.length-1)) {
-							rawmessage += ',';
-						}
+
+		let port = navigator().openMidiOut(midiPort)
+			.or(function () {
+				callback({ result: 'could-not-open-midi-out' });
+			})
+			.and(function () {
+				if (!Number.isInteger(channel)) {
+					channel = 0;
+				}
+				if (!Number.isInteger(note)) {
+					note = 21;
+				}
+				if (!Number.isInteger(velocity)) {
+					if (messageType === 'on') {
+						velocity = 127;
 					}
-					AddToLog(midiPort, 'noteon', rawmessage);
-					returnObj = {result: 'noteon-sent-successfully', midiport: midiPort, note: note, channel: channel, velocity: velocity, message: rawmessage};
-					break;
-				case 'off':
-					msg = navigator.MIDI.noteOff(channel, note, velocity);
-					this.send(msg).close();
-					console.log(clc.magenta.bold('Note Off Sent.'));
-					for (let i = 0; i < msg.length; i++) {
-						rawmessage += msg[i];
-						if (i < (msg.length-1)) {
-							rawmessage += ',';
-						}
+					else {
+						velocity = 0;
 					}
-					AddToLog(midiPort, 'noteoff', rawmessage);
-					returnObj = {result: 'noteoff-sent-successfully', midiport: midiPort, note: note, channel: channel, velocity: velocity, message: rawmessage};
-					break;
-				default:
-					break;
-			}
-			
-			callback(returnObj);
-		});
+				}
+
+				let midiObj = { channel: channel, note: note, velocity: velocity };
+				console.log(midiObj);
+
+				let msg = null;
+
+				let returnObj;
+
+				let rawmessage = '';
+
+				switch (messageType) {
+					case 'on':
+						msg = navigator.MIDI.noteOn(channel, note, velocity);
+						this.send(msg).close();
+						console.log(clc.magenta.bold('Note On Sent.'));
+						for (let i = 0; i < msg.length; i++) {
+							rawmessage += msg[i];
+							if (i < (msg.length - 1)) {
+								rawmessage += ',';
+							}
+						}
+						AddToLog(midiPort, 'noteon', rawmessage);
+						returnObj = { result: 'noteon-sent-successfully', midiport: midiPort, note: note, channel: channel, velocity: velocity, message: rawmessage };
+						break;
+					case 'off':
+						msg = navigator.MIDI.noteOff(channel, note, velocity);
+						this.send(msg).close();
+						console.log(clc.magenta.bold('Note Off Sent.'));
+						for (let i = 0; i < msg.length; i++) {
+							rawmessage += msg[i];
+							if (i < (msg.length - 1)) {
+								rawmessage += ',';
+							}
+						}
+						AddToLog(midiPort, 'noteoff', rawmessage);
+						returnObj = { result: 'noteoff-sent-successfully', midiport: midiPort, note: note, channel: channel, velocity: velocity, message: rawmessage };
+						break;
+					default:
+						break;
+				}
+
+				callback(returnObj);
+			});
 	}
-	catch(error) {
-		callback({result: 'error', error: error});
+	catch (error) {
+		callback({ result: 'error', error: error });
 	}
 }
 
 function SendMIDI_Aftertouch(midiPort, channel, note, value, callback) {
 	try {
 		console.log(clc.magenta.bold('Sending Polyphonic AfterTouch to Port: ') + midiPort);
-		
+
 		let port = navigator().openMidiOut(midiPort)
-		.or(function() {
-			callback({result: 'could-not-open-midi-out'});
-		})
-		.and(function() {
-			if (!Number.isInteger(channel)) {
-				channel = 0;
-			}
-			if (!Number.isInteger(note)) {
-				note = 21;
-			}
-			if (!Number.isInteger(value)) {
-				value = 1;
-			}
-
-			let midiObj = {channel: channel, note: note, value: value};
-			console.log(midiObj);
-			
-			let msg = navigator.MIDI.aftertouch(channel, note, value);
-			this.send(msg).close();
-
-			console.log(clc.magenta.bold('Polyphonic Aftertouch Sent.'));
-			let rawmessage = '';
-			for (let i = 0; i < msg.length; i++) {
-				rawmessage += msg[i];
-				if (i < (msg.length-1)) {
-					rawmessage += ',';
+			.or(function () {
+				callback({ result: 'could-not-open-midi-out' });
+			})
+			.and(function () {
+				if (!Number.isInteger(channel)) {
+					channel = 0;
 				}
-			}
-			AddToLog(midiPort, 'aftertouch', rawmessage);
-			callback({result: 'aftertouch-sent-successfully', midiport: midiPort, channel: channel, note: note, value: value, message: rawmessage});
-		});
+				if (!Number.isInteger(note)) {
+					note = 21;
+				}
+				if (!Number.isInteger(value)) {
+					value = 1;
+				}
+
+				let midiObj = { channel: channel, note: note, value: value };
+				console.log(midiObj);
+
+				let msg = navigator.MIDI.aftertouch(channel, note, value);
+				this.send(msg).close();
+
+				console.log(clc.magenta.bold('Polyphonic Aftertouch Sent.'));
+				let rawmessage = '';
+				for (let i = 0; i < msg.length; i++) {
+					rawmessage += msg[i];
+					if (i < (msg.length - 1)) {
+						rawmessage += ',';
+					}
+				}
+				AddToLog(midiPort, 'aftertouch', rawmessage);
+				callback({ result: 'aftertouch-sent-successfully', midiport: midiPort, channel: channel, note: note, value: value, message: rawmessage });
+			});
 	}
-	catch(error) {
-		callback({result: 'error', error: error});
+	catch (error) {
+		callback({ result: 'error', error: error });
 	}
 }
 
 function SendMIDI_CC(midiPort, channel, controller, value, callback) {
-		try {
+	try {
 		console.log(clc.magenta.bold('Sending Control Change to Port: ') + midiPort);
-		
+
 		let port = navigator().openMidiOut(midiPort)
-		.or(function() {
-			callback({result: 'could-not-open-midi-out'});
-		})
-		.and(function() {
-			if (!Number.isInteger(channel)) {
-				channel = 0;
-			}
-			if (!Number.isInteger(controller)) {
-				controller = 0;
-			}
-			if (!Number.isInteger(value)) {
-				value = 1;
-			}
-
-			let midiObj = {channel: channel, controller: controller, value: value};
-			console.log(midiObj);
-			
-			let msg = navigator.MIDI.control(channel, controller, value);
-			this.send(msg).close();
-
-			console.log(clc.magenta.bold('Control Change Sent.'));
-			let rawmessage = '';
-			for (let i = 0; i < msg.length; i++) {
-				rawmessage += msg[i];
-				if (i < (msg.length-1)) {
-					rawmessage += ',';
+			.or(function () {
+				callback({ result: 'could-not-open-midi-out' });
+			})
+			.and(function () {
+				if (!Number.isInteger(channel)) {
+					channel = 0;
 				}
-			}
-			AddToLog(midiPort, 'cc', rawmessage);
-			callback({result: 'cc-sent-successfully', midiport: midiPort, channel: channel, controller: controller, value: value, message: rawmessage});
-		});
+				if (!Number.isInteger(controller)) {
+					controller = 0;
+				}
+				if (!Number.isInteger(value)) {
+					value = 1;
+				}
+
+				let midiObj = { channel: channel, controller: controller, value: value };
+				console.log(midiObj);
+
+				let msg = navigator.MIDI.control(channel, controller, value);
+				this.send(msg).close();
+
+				console.log(clc.magenta.bold('Control Change Sent.'));
+				let rawmessage = '';
+				for (let i = 0; i < msg.length; i++) {
+					rawmessage += msg[i];
+					if (i < (msg.length - 1)) {
+						rawmessage += ',';
+					}
+				}
+				AddToLog(midiPort, 'cc', rawmessage);
+				callback({ result: 'cc-sent-successfully', midiport: midiPort, channel: channel, controller: controller, value: value, message: rawmessage });
+			});
 	}
-	catch(error) {
-		callback({result: 'error', error: error});
+	catch (error) {
+		callback({ result: 'error', error: error });
 	}
 }
 
 function SendMIDI_PC(midiPort, channel, value, callback) {
 	try {
 		console.log(clc.magenta.bold('Sending Program Change to Port: ') + midiPort);
-		
+
 		let port = navigator().openMidiOut(midiPort)
-		.or(function() {
-			callback({result: 'could-not-open-midi-out'});
-		})
-		.and(function() {
-			if (!Number.isInteger(channel)) {
-				channel = 0;
-			}
-			if (!Number.isInteger(value)) {
-				value = 1;
-			}
-
-			let midiObj = {channel: channel, value: value};
-			console.log(midiObj);
-
-			let msg = navigator.MIDI.program(channel, value);
-			this.send(msg).close();
-
-			console.log(clc.magenta.bold('Program Change Sent.'));
-			let rawmessage = '';
-			for (let i = 0; i < msg.length; i++) {
-				rawmessage += msg[i];
-				if (i < (msg.length-1)) {
-					rawmessage += ',';
+			.or(function () {
+				callback({ result: 'could-not-open-midi-out' });
+			})
+			.and(function () {
+				if (!Number.isInteger(channel)) {
+					channel = 0;
 				}
-			}
-			AddToLog(midiPort, 'pc', rawmessage);
-			callback({result: 'pc-sent-successfully', midiport: midiPort, channel: channel, value: value, message: rawmessage});
-		});
+				if (!Number.isInteger(value)) {
+					value = 1;
+				}
+
+				let midiObj = { channel: channel, value: value };
+				console.log(midiObj);
+
+				let msg = navigator.MIDI.program(channel, value);
+				this.send(msg).close();
+
+				console.log(clc.magenta.bold('Program Change Sent.'));
+				let rawmessage = '';
+				for (let i = 0; i < msg.length; i++) {
+					rawmessage += msg[i];
+					if (i < (msg.length - 1)) {
+						rawmessage += ',';
+					}
+				}
+				AddToLog(midiPort, 'pc', rawmessage);
+				callback({ result: 'pc-sent-successfully', midiport: midiPort, channel: channel, value: value, message: rawmessage });
+			});
 	}
-	catch(error) {
-		callback({result: 'error', error: error});
+	catch (error) {
+		callback({ result: 'error', error: error });
 	}
 }
 
 function SendMIDI_Pressure(midiPort, channel, value, callback) {
 	try {
 		console.log(clc.magenta.bold('Sending Channel Pressure / Aftertouch to Port: ') + midiPort);
-		
+
 		let port = navigator().openMidiOut(midiPort)
-		.or(function() {
-			callback({result: 'could-not-open-midi-out'});
-		})
-		.and(function() {
-			if (!Number.isInteger(channel)) {
-				channel = 0;
-			}
-			if (!Number.isInteger(value)) {
-				value = 1;
-			}
-
-			let midiObj = {channel: channel, value: value};
-			console.log(midiObj);
-			
-			let msg = navigator.MIDI.pressure(channel, value);
-			this.send(msg).close();
-
-			console.log(clc.magenta.bold('Channel Pressure / Aftertouch Sent.'));
-			let rawmessage = '';
-			for (let i = 0; i < msg.length; i++) {
-				rawmessage += msg[i];
-				if (i < (msg.length-1)) {
-					rawmessage += ',';
+			.or(function () {
+				callback({ result: 'could-not-open-midi-out' });
+			})
+			.and(function () {
+				if (!Number.isInteger(channel)) {
+					channel = 0;
 				}
-			}
-			AddToLog(midiPort, 'pressure', rawmessage);
-			callback({result: 'pressure-sent-successfully', midiport: midiPort, channel: channel, value: value, message: rawmessage});
-		});
+				if (!Number.isInteger(value)) {
+					value = 1;
+				}
+
+				let midiObj = { channel: channel, value: value };
+				console.log(midiObj);
+
+				let msg = navigator.MIDI.pressure(channel, value);
+				this.send(msg).close();
+
+				console.log(clc.magenta.bold('Channel Pressure / Aftertouch Sent.'));
+				let rawmessage = '';
+				for (let i = 0; i < msg.length; i++) {
+					rawmessage += msg[i];
+					if (i < (msg.length - 1)) {
+						rawmessage += ',';
+					}
+				}
+				AddToLog(midiPort, 'pressure', rawmessage);
+				callback({ result: 'pressure-sent-successfully', midiport: midiPort, channel: channel, value: value, message: rawmessage });
+			});
 	}
-	catch(error) {
-		callback({result: 'error', error: error});
+	catch (error) {
+		callback({ result: 'error', error: error });
 	}
 }
 
 function SendMIDI_PitchBend(midiPort, channel, value, callback) {
-		try {
+	try {
 		console.log(clc.magenta.bold('Sending Pitch Bend to Port: ') + midiPort);
-		
+
 		let port = navigator().openMidiOut(midiPort)
-		.or(function() {
-			callback({result: 'could-not-open-midi-out'});
-		})
-		.and(function() {
-			if (!Number.isInteger(channel)) {
-				channel = 0;
-			}
-			if (!Number.isInteger(value)) {
-				value = 1;
-			}
-
-			let midiObj = {channel: channel, value: value};
-			console.log(midiObj);
-			
-			let msg = navigator.MIDI.pitchBend(channel, value);
-			this.send(msg).close();
-
-			console.log(clc.magenta.bold('Pitch Bend Sent.'));
-			let rawmessage = '';
-			for (let i = 0; i < msg.length; i++) {
-				rawmessage += msg[i];
-				if (i < (msg.length-1)) {
-					rawmessage += ',';
+			.or(function () {
+				callback({ result: 'could-not-open-midi-out' });
+			})
+			.and(function () {
+				if (!Number.isInteger(channel)) {
+					channel = 0;
 				}
-			}
-			AddToLog(midiPort, 'pitchbend', rawmessage);
-			callback({result: 'pitchbend-sent-successfully', midiport, midiPort, channel: channel, value: value, message: rawmessage});
-		});
+				if (!Number.isInteger(value)) {
+					value = 1;
+				}
+
+				let midiObj = { channel: channel, value: value };
+				console.log(midiObj);
+
+				let msg = navigator.MIDI.pitchBend(channel, value);
+				this.send(msg).close();
+
+				console.log(clc.magenta.bold('Pitch Bend Sent.'));
+				let rawmessage = '';
+				for (let i = 0; i < msg.length; i++) {
+					rawmessage += msg[i];
+					if (i < (msg.length - 1)) {
+						rawmessage += ',';
+					}
+				}
+				AddToLog(midiPort, 'pitchbend', rawmessage);
+				callback({ result: 'pitchbend-sent-successfully', midiport, midiPort, channel: channel, value: value, message: rawmessage });
+			});
 	}
-	catch(error) {
-		callback({result: 'error', error: error});
+	catch (error) {
+		callback({ result: 'error', error: error });
 	}
 }
 
 function SendMIDI_MSC(midiPort, deviceId, commandFormat, command, cue, cueList, cuePath, callback) {
 	try {
 		console.log(clc.magenta.bold('Sending MSC to Port: ') + midiPort);
-		
+
 		let port = navigator().openMidiOut(midiPort)
-		.or(function() {
-			callback({result: 'could-not-open-midi-out'});
-		})
-		.and(function() {
-			//check if cue, cueList, or cuePath are included (they are optional)
-			let midiObj = {};
+			.or(function () {
+				callback({ result: 'could-not-open-midi-out' });
+			})
+			.and(function () {
+				//check if cue, cueList, or cuePath are included (they are optional)
+				let midiObj = {};
 
-			midiObj.deviceId = deviceId;
-			midiObj.commandFormat = commandFormat;
-			midiObj.command = command;
-			if (cue !== '') {
-				midiObj.cue = cue;
-			}
-			if (cueList !== '') {
-				midiObj.cueList = cueList;
-			}
-			if (cuePath !== '') {
-				midiObj.cuePath = cuePath;
-			}
-
-			console.log(midiObj);
-
-			let message = BuildMSC(deviceId, commandFormat, command, cue, cueList, cuePath);			
-			this.send(message).close();
-			
-			console.log(clc.magenta.bold('MSC Sent.'));
-			let rawmessage = '';
-			for (let i = 0; i < message.length; i++) {
-				rawmessage += message[i];
-				if (i < (message.length-1)) {
-					rawmessage += ',';
+				midiObj.deviceId = deviceId;
+				midiObj.commandFormat = commandFormat;
+				midiObj.command = command;
+				if (cue !== '') {
+					midiObj.cue = cue;
 				}
-			}
+				if (cueList !== '') {
+					midiObj.cueList = cueList;
+				}
+				if (cuePath !== '') {
+					midiObj.cuePath = cuePath;
+				}
+
+				console.log(midiObj);
+
+				let message = BuildMSC(deviceId, commandFormat, command, cue, cueList, cuePath);
+				this.send(message).close();
+
+				console.log(clc.magenta.bold('MSC Sent.'));
+				let rawmessage = '';
+				for (let i = 0; i < message.length; i++) {
+					rawmessage += message[i];
+					if (i < (message.length - 1)) {
+						rawmessage += ',';
+					}
+				}
 				AddToLog(midiPort, 'sysex', rawmessage);
-			callback({result: 'msc-sent-successfully', midiport: midiPort, deviceid: deviceId, commandformat: commandFormat, command: command, cue: cue, cuelist: cueList, cuepath: cuePath, message: message});
-		});
+				callback({ result: 'msc-sent-successfully', midiport: midiPort, deviceid: deviceId, commandformat: commandFormat, command: command, cue: cue, cuelist: cueList, cuepath: cuePath, message: message });
+			});
 	}
-	catch(error) {
-		return {result: 'error', error: error};
+	catch (error) {
+		return { result: 'error', error: error };
 	}
 }
 
@@ -805,15 +802,15 @@ function BuildMSC(deviceId, commandFormat, command, cue, cueList, cuePath) {
 	let cue_hex = null;
 	let cueList_hex = null;
 	let cuePath_hex = null;
-	
+
 	if (parseInt(deviceId) !== 'NaN') {
 		deviceId_hex = parseIntegerDeviceId(parseInt(deviceId));
 	}
 	else {
 		deviceId_hex = parseStringDeviceId(deviceId);
 	}
-		
-	switch(commandFormat) {
+
+	switch (commandFormat) {
 		case 'lighting.general':
 			commandFormat_hex = 0x01;
 			break;
@@ -839,8 +836,8 @@ function BuildMSC(deviceId, commandFormat, command, cue, cueList, cuePath) {
 			commandFormat_hex = 0x7F;
 			break;
 	}
-	
-	switch(command) {
+
+	switch (command) {
 		case 'go':
 			command_hex = 0x01;
 			break;
@@ -897,33 +894,33 @@ function BuildMSC(deviceId, commandFormat, command, cue, cueList, cuePath) {
 	if ((cue !== '') && (cue !== undefined)) {
 		cue_hex = stringToByteArray(cue);
 	}
-	
+
 	if ((cueList !== '') && (cueList !== undefined)) {
 		cueList_hex = stringToByteArray(cueList);
 	}
-	
+
 	if ((cuePath !== '') && (cuePath !== undefined)) {
 		cuePath_hex = stringToByteArray(cuePath);
 	}
-	
-	var message = [ 0xF0, 0x7F, deviceId_hex, 0x02, commandFormat_hex, command_hex];
-	
+
+	var message = [0xF0, 0x7F, deviceId_hex, 0x02, commandFormat_hex, command_hex];
+
 	if (cue_hex !== null) {
 		message.push(cue_hex);
 	}
-	
+
 	if (cueList_hex !== null) {
 		message.push(0x00);
 		message.push(cueList_hex);
 	}
-	
+
 	if (cuePath_hex !== null) {
 		message.push(0x00);
 		message.push(cuePath_hex);
 	}
-	
+
 	message.push(0xF7);
-	
+
 	return _.flatten(message);
 }
 
@@ -933,7 +930,7 @@ function stringToByteArray(str) {
 	}
 
 	var ret = [];
-	for (var i=0; i<str.length; i++) {
+	for (var i = 0; i < str.length; i++) {
 		var char = parseInt(str.charCodeAt(i));
 		ret.push(char);
 	}
@@ -953,7 +950,7 @@ function parseStringDeviceId(deviceId) {
 			throw new Error('Group numbers must be within 1 and 15.');
 		}
 		return 0x6F + g;
-}
+	}
 
 	throw new Error('Invalid deviceId.');
 }
@@ -962,55 +959,55 @@ function parseIntegerDeviceId(deviceId) {
 	if (deviceId >= 0x00 && deviceId <= 0x6F) {
 		return _.parseInt(deviceId);
 	}
-	
+
 	throw new Error('Integer deviceIds must be between 0 (0x00) and 111 (0x6F)');
 }
 
 function SendMIDI_SysEx(midiPort, message, callback) {
 	try {
 		console.log(clc.magenta.bold('Sending SysEx MIDI Message to Port: ') + midiPort);
-		
-		let port = navigator().openMidiOut(midiPort)
-		.or(function() {
-			callback({result: 'could-not-open-midi-out'});
-		})
-		.and(function() {
-			let messageArray = message.replace(' ', ',').split(',');
-			let statusByte = messageArray[0];
-			if (statusByte.toLowerCase().indexOf('0x') === -1) { //if the status byte was not provided in hexadecimal notation
-				//convert it to hexadecimal for comparison
-				statusByte = parseInt(statusByte, 10).toString(16);
-			}
-			else {
-				statusByte = statusByte.substring(2,4).toLowerCase();
-			}
-			if (statusByte.toLowerCase() !== 'f0') {
-				//not a SysEx message
-				console.log(clc.red.bold('Not a valid SysEx message.'));
-				console.log(messageArray);
-				callback({result: 'sysex-invalid', message: messageArray});
-			}
-			else {
-				let midiObj = {message: messageArray};
-				console.log(midiObj);
-				
-				this.send(messageArray).close();
 
-				console.log(clc.magenta.bold('SysEx Sent.'));
-				let rawmessage = '';
-				for (let i = 0; i < messageArray.length; i++) {
-					rawmessage += messageArray[i];
-					if (i < (messageArray.length-1)) {
-						rawmessage += ',';
-					}
+		let port = navigator().openMidiOut(midiPort)
+			.or(function () {
+				callback({ result: 'could-not-open-midi-out' });
+			})
+			.and(function () {
+				let messageArray = message.replace(' ', ',').split(',');
+				let statusByte = messageArray[0];
+				if (statusByte.toLowerCase().indexOf('0x') === -1) { //if the status byte was not provided in hexadecimal notation
+					//convert it to hexadecimal for comparison
+					statusByte = parseInt(statusByte, 10).toString(16);
 				}
-				AddToLog(midiPort, 'sysex', rawmessage);
-				callback({result: 'sysex-sent-successfully', midiport: midiPort, message: rawmessage});
-			}
-		});
+				else {
+					statusByte = statusByte.substring(2, 4).toLowerCase();
+				}
+				if (statusByte.toLowerCase() !== 'f0') {
+					//not a SysEx message
+					console.log(clc.red.bold('Not a valid SysEx message.'));
+					console.log(messageArray);
+					callback({ result: 'sysex-invalid', message: messageArray });
+				}
+				else {
+					let midiObj = { message: messageArray };
+					console.log(midiObj);
+
+					this.send(messageArray).close();
+
+					console.log(clc.magenta.bold('SysEx Sent.'));
+					let rawmessage = '';
+					for (let i = 0; i < messageArray.length; i++) {
+						rawmessage += messageArray[i];
+						if (i < (messageArray.length - 1)) {
+							rawmessage += ',';
+						}
+					}
+					AddToLog(midiPort, 'sysex', rawmessage);
+					callback({ result: 'sysex-sent-successfully', midiport: midiPort, message: rawmessage });
+				}
+			});
 	}
-	catch(error) {
-		callback({result: 'error', error: error});
+	catch (error) {
+		callback({ result: 'error', error: error });
 	}
 }
 
@@ -1025,7 +1022,7 @@ function AddToLog(midiPort, midiCommand, message) {
 
 function CheckLog(midiPort, midiCommand, message, time) {
 	let passed = true;
-	
+
 	for (let i = 0; i < MIDIRelaysLog.length; i++) {
 		if (MIDIRelaysLog[i].midiport === midiPort) {
 			if (MIDIRelaysLog[i].midicommand === midiCommand) {
@@ -1039,16 +1036,16 @@ function CheckLog(midiPort, midiCommand, message, time) {
 			}
 		}
 	}
-	
+
 	CleanUpLog();
-	
+
 	return passed;
 }
 
 function CleanUpLog() {
 	//loops through the array and removes anything older than 60000ms (1 minute)
 	let time = Date.now();
-	
+
 	for (let i = 0; i < MIDIRelaysLog.length; i++) {
 		if (time - MIDIRelaysLog.datetime > 60000) {
 			MIDIRelaysLog.splice(i, 1);
@@ -1059,28 +1056,28 @@ function CleanUpLog() {
 
 function receiveMIDI(midiArg) {
 	let midiObj = {};
-	
+
 	let statusBytes = [
-		{byte: '8', type: 'noteoff'},
-		{byte: '9', type: 'noteon'},
-		{byte: 'A', type: 'aftertouch'},
-		{byte: 'B', type: 'cc'},
-		{byte: 'C', type: 'pc'},
-		{byte: 'D', type: 'pressure'},
-		{byte: 'E', type: 'pitchbend'},
-		{byte: 'F', type: 'sysex'}
+		{ byte: '8', type: 'noteoff' },
+		{ byte: '9', type: 'noteon' },
+		{ byte: 'A', type: 'aftertouch' },
+		{ byte: 'B', type: 'cc' },
+		{ byte: 'C', type: 'pc' },
+		{ byte: 'D', type: 'pressure' },
+		{ byte: 'E', type: 'pitchbend' },
+		{ byte: 'F', type: 'sysex' }
 	]
-	
-	let midiType = midiArg[0].toString(16).substring(0,1).toUpperCase();
-	let statusByte = statusBytes.find( ({ byte }) => byte === midiType);
+
+	let midiType = midiArg[0].toString(16).substring(0, 1).toUpperCase();
+	let statusByte = statusBytes.find(({ byte }) => byte === midiType);
 	if (statusByte) {
 		let midiCommand = statusByte.type;
 		midiObj.midicommand = midiCommand;
 	}
-	
+
 	midiObj.midiport = this.midiport;
-	
-	switch(midiObj.midicommand) {
+
+	switch (midiObj.midicommand) {
 		case 'noteon':
 			midiObj.channel = midiArg.getChannel();
 			midiObj.note = midiArg.getNote();
@@ -1113,30 +1110,30 @@ function receiveMIDI(midiArg) {
 			midiObj.channel = midiArg.getChannel();
 			let lsb = parseInt(midiArg[1]) << 0;
 			let msb = parseInt(midiArg[2]) << 7;
-			midiObj.value = lsb+msb;
+			midiObj.value = lsb + msb;
 			break;
 		case 'sysex':
 			midiObj.message = '';
 			for (let i = 0; i < midiArg.length; i++) {
 				midiObj.message += midiArg[i];
-				if (i < (midiArg.length-1)) {
+				if (i < (midiArg.length - 1)) {
 					midiObj.message += ',';
 				}
-			}			
+			}
 			break;
 		default:
 			midiObj.midicommand = 'unsupported';
 			break;
 	}
-	
+
 	midiObj.rawmessage = '';
 	for (let i = 0; i < midiArg.length; i++) {
 		midiObj.rawmessage += midiArg[i];
-		if (i < (midiArg.length-1)) {
+		if (i < (midiArg.length - 1)) {
 			midiObj.rawmessage += ',';
 		}
 	}
-	
+
 	if (IncomingMIDIMessageTypes.includes(midiObj.midicommand)) {
 		processMIDI(midiObj);
 	}
@@ -1146,20 +1143,20 @@ function receiveMIDI(midiArg) {
 	}
 }
 
-function processMIDI(midiObj) {	
-	let port = MIDI_inputs.find( ({ name }) => name === midiObj.midiport);
-	
+function processMIDI(midiObj) {
+	let port = MIDI_inputs.find(({ name }) => name === midiObj.midiport);
+
 	if (port.opened) {
 		let passed = true;
-		
+
 		passed = CheckLog(midiObj.midiport, midiObj.midicommand, midiObj.rawmessage, Date.now());
-		
+
 		if (passed) {
 			console.log(clc.cyan.bold('Processing MIDI Triggers for: ') + midiObj.midiport + ' ' + clc.magenta(midiObj.midicommand));
 			console.log(midiObj);
 			for (let i = 0; i < Triggers.length; i++) {
 				if ((Triggers[i].midiport === midiObj.midiport) && (Triggers[i].midicommand === midiObj.midicommand)) {
-					switch(Triggers[i].midicommand) {
+					switch (Triggers[i].midicommand) {
 						case 'noteon':
 						case 'noteoff':
 							if ((parseInt(Triggers[i].channel) === parseInt(midiObj.channel)) || (Triggers[i].channel === '*')) {
@@ -1211,7 +1208,7 @@ function processMIDI(midiObj) {
 							if ((parseInt(Triggers[i].channel) === parseInt(midiObj.channel)) || (Triggers[i].channel === '*')) {
 								if ((parseInt(Triggers[i].value) === parseInt(midiObj.value)) || (Triggers[i].value === '*')) {
 									//trigger is a match, run the trigger
-									setTimeout(runMIDITrigger, 1, Triggers[i]);	
+									setTimeout(runMIDITrigger, 1, Triggers[i]);
 								}
 							}
 							break;
@@ -1234,8 +1231,8 @@ function processMIDI(midiObj) {
 
 function runMIDITrigger(midiTriggerObj) {
 	console.log(clc.cyan.bold('Running MIDI Trigger: ' + midiTriggerObj.id));
-	
-	switch(midiTriggerObj.actiontype) {
+
+	switch (midiTriggerObj.actiontype) {
 		case 'http':
 			console.log(clc.cyan('Type: HTTP'));
 			runMIDITrigger_HTTP(midiTriggerObj);
@@ -1261,7 +1258,7 @@ function runMIDITrigger_HTTP(midiTriggerObj) {
 		try {
 			console.log(clc.cyan('JSON Data: '));
 			console.log(midiTriggerObj.jsondata);
-			
+
 			request.post(
 				midiTriggerObj.url,
 				{ json: JSON.parse(midiTriggerObj.jsondata), strictSSL: false },
@@ -1303,14 +1300,14 @@ function runMIDITrigger_HTTP(midiTriggerObj) {
 
 function runMIDITrigger_AppleScript(applescript) {
 	//run the specified AppleScript
-	
+
 	if (process.platform === 'darwin') {
 		var osascript = require('node-osascript');
 
 		console.log(clc.cyan.bold('Executing AppleScript:'));
 		console.log(applescript);
 
-		osascript.execute(applescript, function(err, result, raw) {
+		osascript.execute(applescript, function (err, result, raw) {
 			if (err) {
 				console.log(clc.red(err));
 			}
@@ -1338,25 +1335,25 @@ function runMIDITrigger_ShellScript(shellscript) {
 }
 
 function uuidv4() { //unique UUID generator for IDs
-	return 'xxxxxxxx'.replace(/[xy]/g, function(c) {
+	return 'xxxxxxxx'.replace(/[xy]/g, function (c) {
 		var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
 		return v.toString(16);
 	});
 }
 
 function isHex(h) {
-	let a = parseInt(h,16);
+	let a = parseInt(h, 16);
 	return (a.toString(16) === h.toLowerCase());
 }
 
 function AddTrigger(triggerObj) {
 	//add the Trigger to the array
 	triggerObj.id = 'trigger-' + uuidv4();
-	
+
 	let passed = true;
-	
+
 	let index = null;
-	
+
 	if (triggerObj.midiport) {
 		MIDI_inputs.find((o, i) => {
 			if (o.name === triggerObj.midiport) {
@@ -1372,13 +1369,13 @@ function AddTrigger(triggerObj) {
 	else {
 		return 'invalid-midi-port';
 	}
-	
+
 	if (triggerObj.midicommand) {
 		if (!IncomingMIDIMessageTypes.includes(triggerObj.midicommand.toLowerCase())) {
 			return 'invalid-midi-command';
 		}
 		else {
-			switch(triggerObj.midicommand) {
+			switch (triggerObj.midicommand) {
 				case 'noteon':
 					if (!Number.isInteger(triggerObj.channel)) {
 						if (triggerObj.channel !== '*') {
@@ -1485,7 +1482,7 @@ function AddTrigger(triggerObj) {
 							//assume dec
 							triggerObj.message += parseInt(msgArray[i]);
 						}
-						if (i < (msgArray-1)) {
+						if (i < (msgArray - 1)) {
 							triggerObj.message += ',';
 						}
 					}
@@ -1498,7 +1495,7 @@ function AddTrigger(triggerObj) {
 	else {
 		return 'invalid-midi-command';
 	}
-	
+
 	if (triggerObj.actiontype) {
 		if (!ActionTypes.includes(triggerObj.actiontype.toLowerCase())) {
 			return 'invalid-action-type';
@@ -1507,33 +1504,33 @@ function AddTrigger(triggerObj) {
 	else {
 		return 'invalid-action-type';
 	}
-	
+
 	if (passed) {
 		Triggers.push(triggerObj);
 		console.log(clc.cyan.bold('New MIDI Trigger Added - ' + triggerObj.id));
 		saveMIDITriggers();
-		
-		if (triggerObj.midiport) {			
+
+		if (triggerObj.midiport) {
 			for (let i = 0; i < MIDI_inputs.length; i++) {
 				if (MIDI_inputs[i].name === triggerObj.midiport) {
 					if (!MIDI_inputs[i].opened) {
 						console.log(clc.cyan.bold('Attempting to open MIDI port: ' + triggerObj.midiport));
 						navigator().openMidiIn(triggerObj.midiport)
-						.or(function () {
-							console.log(clc.red.bold('Cannot open MIDI port specified in trigger. It may no longer be available.'));
-							return 'trigger-added-midiin-port-cannot-be-opened';
-						})
-						.and(function() {
-							for (let i = 0; i < MIDI_inputs.length; i++) {
-								if (MIDI_inputs[i].name === this.name()) {
-									MIDI_inputs[i].opened = true;
-									break;
+							.or(function () {
+								console.log(clc.red.bold('Cannot open MIDI port specified in trigger. It may no longer be available.'));
+								return 'trigger-added-midiin-port-cannot-be-opened';
+							})
+							.and(function () {
+								for (let i = 0; i < MIDI_inputs.length; i++) {
+									if (MIDI_inputs[i].name === this.name()) {
+										MIDI_inputs[i].opened = true;
+										break;
+									}
 								}
-							}
-							console.log(clc.green.bold('Port opened successfully: ' + triggerObj.midiport));
-							this.connect(receiveMIDI.bind({'midiport': triggerObj.midiport}));
-							return 'trigger-added';	
-						});
+								console.log(clc.green.bold('Port opened successfully: ' + triggerObj.midiport));
+								this.connect(receiveMIDI.bind({ 'midiport': triggerObj.midiport }));
+								return 'trigger-added';
+							});
 					}
 					else {
 						return 'trigger-added';
@@ -1547,9 +1544,9 @@ function AddTrigger(triggerObj) {
 function EditTrigger(triggerObj) {
 	//edit the Trigger in the array	
 	let passed = true;
-	
+
 	let index = null;
-	
+
 	if (triggerObj.midiport) {
 		MIDI_inputs.find((o, i) => {
 			if (o.name === triggerObj.midiport) {
@@ -1565,13 +1562,13 @@ function EditTrigger(triggerObj) {
 	else {
 		return 'invalid-midi-port';
 	}
-	
+
 	if (triggerObj.midicommand) {
 		if (!IncomingMIDIMessageTypes.includes(triggerObj.midicommand.toLowerCase())) {
 			return 'invalid-midi-command';
 		}
 		else {
-			switch(triggerObj.midicommand) {
+			switch (triggerObj.midicommand) {
 				case 'noteon':
 					if (!Number.isInteger(triggerObj.channel)) {
 						if (triggerObj.channel !== '*') {
@@ -1678,7 +1675,7 @@ function EditTrigger(triggerObj) {
 							//assume dec
 							triggerObj.message += parseInt(msgArray[i]);
 						}
-						if (i < (msgArray-1)) {
+						if (i < (msgArray - 1)) {
 							triggerObj.message += ',';
 						}
 					}
@@ -1691,7 +1688,7 @@ function EditTrigger(triggerObj) {
 	else {
 		return 'invalid-midi-command';
 	}
-	
+
 	if (triggerObj.actiontype) {
 		if (!ActionTypes.includes(triggerObj.actiontype.toLowerCase())) {
 			return 'invalid-action-type';
@@ -1700,36 +1697,36 @@ function EditTrigger(triggerObj) {
 	else {
 		return 'invalid-action-type';
 	}
-	
+
 	if (passed) {
 		let tempTriggers = [];
 		tempTriggers.push(triggerObj);
 		Triggers = Triggers.map(obj => tempTriggers.find(o => o.id === obj.id) || obj);
-		
+
 		console.log(clc.cyan.bold('MIDI Trigger Edited - ' + triggerObj.id));
 		saveMIDITriggers();
-		
-		if (triggerObj.midiport) {			
+
+		if (triggerObj.midiport) {
 			for (let i = 0; i < MIDI_inputs.length; i++) {
 				if (MIDI_inputs[i].name === triggerObj.midiport) {
 					if (!MIDI_inputs[i].opened) {
 						console.log(clc.cyan.bold('Attempting to open MIDI port: ' + triggerObj.midiport));
 						navigator().openMidiIn(triggerObj.midiport)
-						.or(function () {
-							console.log(clc.red.bold('Cannot open MIDI port specified in trigger. It may no longer be available.'));
-							return 'trigger-edited-midiin-port-cannot-be-opened';
-						})
-						.and(function() {
-							for (let i = 0; i < MIDI_inputs.length; i++) {
-								if (MIDI_inputs[i].name === this.name()) {
-									MIDI_inputs[i].opened = true;
-									break;
+							.or(function () {
+								console.log(clc.red.bold('Cannot open MIDI port specified in trigger. It may no longer be available.'));
+								return 'trigger-edited-midiin-port-cannot-be-opened';
+							})
+							.and(function () {
+								for (let i = 0; i < MIDI_inputs.length; i++) {
+									if (MIDI_inputs[i].name === this.name()) {
+										MIDI_inputs[i].opened = true;
+										break;
+									}
 								}
-							}
-							console.log(clc.green.bold('Port opened successfully: ' + triggerObj.midiport));
-							this.connect(receiveMIDI.bind({'midiport': triggerObj.midiport}));
-							return 'trigger-edited';	
-						});
+								console.log(clc.green.bold('Port opened successfully: ' + triggerObj.midiport));
+								this.connect(receiveMIDI.bind({ 'midiport': triggerObj.midiport }));
+								return 'trigger-edited';
+							});
 					}
 					else {
 						return 'trigger-edited';
@@ -1745,8 +1742,7 @@ function DeleteTrigger(triggerID) {
 	let index = null;
 
 	Triggers.find((o, i) => {
-		if (o.id === triggerID)
-		{
+		if (o.id === triggerID) {
 			index = i;
 		}
 	});
@@ -1762,8 +1758,8 @@ function DeleteTrigger(triggerID) {
 	}
 }
 
-process.on('uncaughtException', function(err) {
-	if(err.errno === 'EADDRINUSE') {
+process.on('uncaughtException', function (err) {
+	if (err.errno === 'EADDRINUSE') {
 		console.log(clc.red.bold('Unable to start server on port ' + listenPort + '.') + ' Is midi-relay already running?');
 		process.exit(1);
 	}
@@ -1773,7 +1769,7 @@ process.on('uncaughtException', function(err) {
 			console.log('MDNS Error: ' + err.toString());
 		}
 		else {
-			console.log('midi-relay Error occurred:');	
+			console.log('midi-relay Error occurred:');
 			console.log(err);
 			process.exit(1);
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2207 @@
+{
+	"name": "midi-relay",
+	"version": "2.3.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "midi-relay",
+			"version": "2.3.0",
+			"license": "MIT",
+			"dependencies": {
+				"body-parser": "^1.18.3",
+				"cli-color": "^2.0.0",
+				"cors": "^2.8.5",
+				"express": "^4.16.3",
+				"figlet": "^1.2.4",
+				"jquery": "^3.3.1",
+				"jzz": "^0.7.9",
+				"lodash": "^4.17.11",
+				"mdns-js": "^1.0.3",
+				"node-osascript": "^2.1.0",
+				"request": "^2.88.0"
+			},
+			"bin": {
+				"midi-relay": "main.js"
+			}
+		},
+		"node_modules/accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"dependencies": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+		},
+		"node_modules/asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"dependencies": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"node_modules/assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"node_modules/aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/aws4": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+		},
+		"node_modules/bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"node_modules/body-parser": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+			"integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+			"dependencies": {
+				"bytes": "3.1.2",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"on-finished": "2.4.1",
+				"qs": "6.10.3",
+				"raw-body": "2.5.1",
+				"type-is": "~1.6.18",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/buffers": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+			"engines": {
+				"node": ">=0.2.0"
+			}
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dependencies": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+		},
+		"node_modules/cli-color": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.2.tgz",
+			"integrity": "sha512-g4JYjrTW9MGtCziFNjkqp3IMpGhnJyeB0lOtRPjQkYhXzKYr6tYnXKyEVnMzITxhpbahsEW9KsxOYIDKwcsIBw==",
+			"dependencies": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.59",
+				"es6-iterator": "^2.0.3",
+				"memoizee": "^0.4.15",
+				"timers-ext": "^0.1.7"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/content-disposition": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+			"dependencies": {
+				"safe-buffer": "5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+		},
+		"node_modules/cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+			"dependencies": {
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
+			}
+		},
+		"node_modules/dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+			"dependencies": {
+				"assert-plus": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/destroy": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/dns-js": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/dns-js/-/dns-js-0.2.1.tgz",
+			"integrity": "sha512-D5ZrNcaDrDMmb6AKqnLUK+WyT4ST8lRNwfq0BpH26OAupFRtQxMNdSxq04HjXvYPQ6U7e2SPCVHWjM2vfOcRyA==",
+			"dependencies": {
+				"debug": "^2.1.0",
+				"qap": "^3.1.2"
+			},
+			"engines": {
+				"node": ">= 4.1.0"
+			}
+		},
+		"node_modules/ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+			"dependencies": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+		},
+		"node_modules/encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/es5-ext": {
+			"version": "0.10.61",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"node_modules/es6-symbol": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+			"dependencies": {
+				"d": "^1.0.1",
+				"ext": "^1.1.2"
+			}
+		},
+		"node_modules/es6-weak-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
+		"node_modules/express": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+			"integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.20.0",
+				"content-disposition": "0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "0.5.0",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "1.2.0",
+				"fresh": "0.5.2",
+				"http-errors": "2.0.0",
+				"merge-descriptors": "1.0.1",
+				"methods": "~1.1.2",
+				"on-finished": "2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "~2.0.7",
+				"qs": "6.10.3",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "0.18.0",
+				"serve-static": "1.15.0",
+				"setprototypeof": "1.2.0",
+				"statuses": "2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/ext": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+			"integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+			"dependencies": {
+				"type": "^2.5.0"
+			}
+		},
+		"node_modules/ext/node_modules/type": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+			"integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"node_modules/extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+			"engines": [
+				"node >=0.6.0"
+			]
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"node_modules/figlet": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.2.tgz",
+			"integrity": "sha512-WOn21V8AhyE1QqVfPIVxe3tupJacq1xGkPTB4iagT6o+P2cAgEOOwIxMftr4+ZCTI6d551ij9j61DFr0nsP2uQ==",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/finalhandler": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+			"integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+			"dependencies": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "2.4.1",
+				"parseurl": "~1.3.3",
+				"statuses": "2.0.1",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 0.12"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"dependencies": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+			"dependencies": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"node_modules/har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/har-validator": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+			"deprecated": "this library is no longer supported",
+			"dependencies": {
+				"ajv": "^6.12.3",
+				"har-schema": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dependencies": {
+				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+			"dependencies": {
+				"depd": "2.0.0",
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": "2.0.1",
+				"toidentifier": "1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			},
+			"engines": {
+				"node": ">=0.8",
+				"npm": ">=1.3.7"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-promise": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+		},
+		"node_modules/is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+		},
+		"node_modules/isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+		},
+		"node_modules/jazz-midi": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/jazz-midi/-/jazz-midi-1.7.5.tgz",
+			"integrity": "sha512-RUxChhn388CZfSymwwgucfaBxGu4Z0eeJOSTnUMsDN2tMx5E8G+o7h2gk/xPaDTfOORnQsJk71VhSuqiw1Hy9Q==",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/jquery": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+		},
+		"node_modules/jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+		},
+		"node_modules/jsprim": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+			"dependencies": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.4.0",
+				"verror": "1.10.0"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
+		},
+		"node_modules/jzz": {
+			"version": "0.7.9",
+			"resolved": "https://registry.npmjs.org/jzz/-/jzz-0.7.9.tgz",
+			"integrity": "sha512-XFWGOQLdS8m9ipJA6qru4u7QB7Nx1LoYmNSAXMrFF9phAspRaLgw5u35lqPMPq920RBM1NOCdSFaCW+EpkA8Pw==",
+			"dependencies": {
+				"jazz-midi": "^1.6.9"
+			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"node_modules/lru-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+			"integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+			"dependencies": {
+				"es5-ext": "~0.10.2"
+			}
+		},
+		"node_modules/mdns-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/mdns-js/-/mdns-js-1.0.3.tgz",
+			"integrity": "sha512-+6NHS48WZ7na7jkE9PB9dRbBGvY0FvAp8nTGp3/u/05WIyq/B37OVfMppIbHyoo9D4yocJGax4Krxfz3nU7EbQ==",
+			"dependencies": {
+				"debug": "~3.1.0",
+				"dns-js": "~0.2.1",
+				"semver": "~5.4.1"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/mdns-js/node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/memoizee": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+			"integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+			"dependencies": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.53",
+				"es6-weak-map": "^2.0.3",
+				"event-emitter": "^0.3.5",
+				"is-promise": "^2.2.2",
+				"lru-queue": "^0.1.0",
+				"next-tick": "^1.1.0",
+				"timers-ext": "^0.1.7"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"node_modules/methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/next-tick": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+		},
+		"node_modules/node-osascript": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-osascript/-/node-osascript-2.1.0.tgz",
+			"integrity": "sha512-rW2vA0OGDGtoB+Ek6tKA7OYsBVzPZucHHssPsCbjOHJEcMLbHCDo+9UjgNX1tUIaSfMUtDLtEqY7JdIIINCkXQ==",
+			"dependencies": {
+				"buffers": "^0.1.1"
+			}
+		},
+		"node_modules/oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+		},
+		"node_modules/performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/psl": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+		},
+		"node_modules/punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/qap": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/qap/-/qap-3.3.1.tgz",
+			"integrity": "sha1-Efno+oiQ/ny5khDA9E0GE7c3LKw=",
+			"engines": {
+				"node": ">=0.4.x"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+			"integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+			"dependencies": {
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"dependencies": {
+				"bytes": "3.1.2",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/request": {
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+			"dependencies": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.5.0",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/request/node_modules/qs": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"node_modules/semver": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/send": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+			"integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+			"dependencies": {
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "2.0.0",
+				"mime": "1.6.0",
+				"ms": "2.1.3",
+				"on-finished": "2.4.1",
+				"range-parser": "~1.2.1",
+				"statuses": "2.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/send/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"node_modules/serve-static": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+			"integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+			"dependencies": {
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "0.18.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+		},
+		"node_modules/side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/sshpk": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+			"dependencies": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			},
+			"bin": {
+				"sshpk-conv": "bin/sshpk-conv",
+				"sshpk-sign": "bin/sshpk-sign",
+				"sshpk-verify": "bin/sshpk-verify"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/timers-ext": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+			"integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+			"dependencies": {
+				"es5-ext": "~0.10.46",
+				"next-tick": "1"
+			}
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dependencies": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+		},
+		"node_modules/type": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+		},
+		"node_modules/type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"dependencies": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
+		}
+	},
+	"dependencies": {
+		"accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"requires": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			}
+		},
+		"ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"requires": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+		},
+		"asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+		},
+		"aws4": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"body-parser": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+			"integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+			"requires": {
+				"bytes": "3.1.2",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"on-finished": "2.4.1",
+				"qs": "6.10.3",
+				"raw-body": "2.5.1",
+				"type-is": "~1.6.18",
+				"unpipe": "1.0.0"
+			}
+		},
+		"buffers": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
+		},
+		"bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			}
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+		},
+		"cli-color": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.2.tgz",
+			"integrity": "sha512-g4JYjrTW9MGtCziFNjkqp3IMpGhnJyeB0lOtRPjQkYhXzKYr6tYnXKyEVnMzITxhpbahsEW9KsxOYIDKwcsIBw==",
+			"requires": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.59",
+				"es6-iterator": "^2.0.3",
+				"memoizee": "^0.4.15",
+				"timers-ext": "^0.1.7"
+			}
+		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"content-disposition": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+			"requires": {
+				"safe-buffer": "5.2.1"
+			}
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+		},
+		"cookie": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+		},
+		"cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"requires": {
+				"object-assign": "^4",
+				"vary": "^1"
+			}
+		},
+		"d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+			"requires": {
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+		},
+		"depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+		},
+		"destroy": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+		},
+		"dns-js": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/dns-js/-/dns-js-0.2.1.tgz",
+			"integrity": "sha512-D5ZrNcaDrDMmb6AKqnLUK+WyT4ST8lRNwfq0BpH26OAupFRtQxMNdSxq04HjXvYPQ6U7e2SPCVHWjM2vfOcRyA==",
+			"requires": {
+				"debug": "^2.1.0",
+				"qap": "^3.1.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+			"requires": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+		},
+		"es5-ext": {
+			"version": "0.10.61",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+			"requires": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"next-tick": "^1.1.0"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+			"requires": {
+				"d": "^1.0.1",
+				"ext": "^1.1.2"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
+		"express": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+			"integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+			"requires": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.20.0",
+				"content-disposition": "0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "0.5.0",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "1.2.0",
+				"fresh": "0.5.2",
+				"http-errors": "2.0.0",
+				"merge-descriptors": "1.0.1",
+				"methods": "~1.1.2",
+				"on-finished": "2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "~2.0.7",
+				"qs": "6.10.3",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "0.18.0",
+				"serve-static": "1.15.0",
+				"setprototypeof": "1.2.0",
+				"statuses": "2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			}
+		},
+		"ext": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+			"integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+			"requires": {
+				"type": "^2.5.0"
+			},
+			"dependencies": {
+				"type": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+					"integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+				}
+			}
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+		},
+		"fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"figlet": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.2.tgz",
+			"integrity": "sha512-WOn21V8AhyE1QqVfPIVxe3tupJacq1xGkPTB4iagT6o+P2cAgEOOwIxMftr4+ZCTI6d551ij9j61DFr0nsP2uQ=="
+		},
+		"finalhandler": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+			"integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "2.4.1",
+				"parseurl": "~1.3.3",
+				"statuses": "2.0.1",
+				"unpipe": "~1.0.0"
+			}
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
+		},
+		"form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+		},
+		"har-validator": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+			"requires": {
+				"ajv": "^6.12.3",
+				"har-schema": "^2.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+		},
+		"http-errors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+			"requires": {
+				"depd": "2.0.0",
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": "2.0.1",
+				"toidentifier": "1.0.1"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+		},
+		"is-promise": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+		},
+		"jazz-midi": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/jazz-midi/-/jazz-midi-1.7.5.tgz",
+			"integrity": "sha512-RUxChhn388CZfSymwwgucfaBxGu4Z0eeJOSTnUMsDN2tMx5E8G+o7h2gk/xPaDTfOORnQsJk71VhSuqiw1Hy9Q=="
+		},
+		"jquery": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+		},
+		"json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+		},
+		"jsprim": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.4.0",
+				"verror": "1.10.0"
+			}
+		},
+		"jzz": {
+			"version": "0.7.9",
+			"resolved": "https://registry.npmjs.org/jzz/-/jzz-0.7.9.tgz",
+			"integrity": "sha512-XFWGOQLdS8m9ipJA6qru4u7QB7Nx1LoYmNSAXMrFF9phAspRaLgw5u35lqPMPq920RBM1NOCdSFaCW+EpkA8Pw==",
+			"requires": {
+				"jazz-midi": "^1.6.9"
+			}
+		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"lru-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+			"integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+			"requires": {
+				"es5-ext": "~0.10.2"
+			}
+		},
+		"mdns-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/mdns-js/-/mdns-js-1.0.3.tgz",
+			"integrity": "sha512-+6NHS48WZ7na7jkE9PB9dRbBGvY0FvAp8nTGp3/u/05WIyq/B37OVfMppIbHyoo9D4yocJGax4Krxfz3nU7EbQ==",
+			"requires": {
+				"debug": "~3.1.0",
+				"dns-js": "~0.2.1",
+				"semver": "~5.4.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+		},
+		"memoizee": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+			"integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+			"requires": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.53",
+				"es6-weak-map": "^2.0.3",
+				"event-emitter": "^0.3.5",
+				"is-promise": "^2.2.2",
+				"lru-queue": "^0.1.0",
+				"next-tick": "^1.1.0",
+				"timers-ext": "^0.1.7"
+			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+		},
+		"mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+		},
+		"mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"requires": {
+				"mime-db": "1.52.0"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+		},
+		"next-tick": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+		},
+		"node-osascript": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-osascript/-/node-osascript-2.1.0.tgz",
+			"integrity": "sha512-rW2vA0OGDGtoB+Ek6tKA7OYsBVzPZucHHssPsCbjOHJEcMLbHCDo+9UjgNX1tUIaSfMUtDLtEqY7JdIIINCkXQ==",
+			"requires": {
+				"buffers": "^0.1.1"
+			}
+		},
+		"oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-inspect": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+		},
+		"on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"requires": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			}
+		},
+		"psl": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+		},
+		"qap": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/qap/-/qap-3.3.1.tgz",
+			"integrity": "sha1-Efno+oiQ/ny5khDA9E0GE7c3LKw="
+		},
+		"qs": {
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+			"integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+			"requires": {
+				"side-channel": "^1.0.4"
+			}
+		},
+		"range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+		},
+		"raw-body": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"requires": {
+				"bytes": "3.1.2",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
+			}
+		},
+		"request": {
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.5.0",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "6.5.3",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+					"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+				}
+			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"semver": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+		},
+		"send": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+			"integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "2.0.0",
+				"mime": "1.6.0",
+				"ms": "2.1.3",
+				"on-finished": "2.4.1",
+				"range-parser": "~1.2.1",
+				"statuses": "2.0.1"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				}
+			}
+		},
+		"serve-static": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+			"integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+			"requires": {
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "0.18.0"
+			}
+		},
+		"setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			}
+		},
+		"sshpk": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			}
+		},
+		"statuses": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+		},
+		"timers-ext": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+			"integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+			"requires": {
+				"es5-ext": "~0.10.46",
+				"next-tick": "1"
+			}
+		},
+		"toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+		},
+		"tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"requires": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+		},
+		"type": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+		},
+		"type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			}
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+		},
+		"uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+		},
+		"uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"midi-relay": "main.js"
 	},
 	"scripts": {
-		"build": "npx pkg --out-path ./build/ --targets node16-macos-x64,node16-win-x64,node16-linux-x64 ."
+		"build": "npx pkg --out-path ./build/ --compress GZip --targets node16-macos-x64,node16-win-x64,node16-linux-x64 ."
 	},
 	"pkg": {
 		"assets": [

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 	"pkg": {
 		"assets": [
 			"./views/**/*",
-			"./node_modules/figlet/fonts/Standard.flf"
+			"./node_modules/figlet/fonts/Standard.flf",
+			"./node_modules/jazz-midi"
 		]
 	},
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
 	"bin": {
 		"midi-relay": "main.js"
 	},
-	"scripts": {},
-	"devDependencies": {},
+	"scripts": {
+		"build": "npx pkg --out-path ./build/ --targets node16-macos-x64,node16-win-x64,node16-linux-x64 ."
+	},
 	"pkg": {
 		"assets": [
 			"./views/**/*",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "midi-relay",
 	"productName": "MIDI Relay",
 	"description": "Listens for HTTP request with JSON payload and relays MIDI/MSC commands on local ports. Also listens for incoming MIDI messages on local ports and can send HTTP requests or run AppleScripts.",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"keywords": [
 		"util",
 		"functional",

--- a/views/settings.html
+++ b/views/settings.html
@@ -85,7 +85,7 @@
 				border-top: #999999 3px solid;
 			}
 		</style>
-		<script src='js/jquery/jquery.min.js'></script>
+		<script src='js/jquery/jquery.js'></script>
 		<script>
 			var selectedTriggerId = null;
 			var triggers = [];


### PR DESCRIPTION
This should resolve the following issues related to loading jQuery in binary builds:
* #23 
* #19 
* #14

This also adds some GitHub Actions to automatically build and package binaries for distribution on some common platforms.

I had some challenges building for the `node16-macos-arm64` target out of the box on my Intel Mac, so I've left that out for now.

Worked out which jQuery file to point to by adding a new route to the Express server:

```javascript
restServer.use('/js-debug/jquery', function (req, res) {
  let files = fs.readdirSync(path.join(__dirname, 'node_modules', 'jquery', 'dist'))
  res.status(200).send(files.join("\n"));
});
```