### PR TITLE
v3.3.0 Update, Make Improvement to Trigger Setting Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
+dist/
 package-lock.json

--- a/contextmenu.js
+++ b/contextmenu.js
@@ -70,6 +70,12 @@ function buildContextMenu() {
 			}
 		},
 		{
+			label: 'Open MIDI Input Trigger Settings',
+			click: function() {
+				shell.openExternal(`http://127.0.0.1:${config.get('apiPort')}`)
+			}
+		},
+		{
 			label: 'Request Help/Support',
 			click: function() {
 				shell.openExternal(config.get('supportUrl'))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "midi-relay",
 	"productName": "midi-relay",
-	"version": "3.2.0",
+	"version": "3.3.0",
 	"description": "Listens for HTTP requests with JSON payload and relays MIDI/MSC commands on local ports.",
 	"license": "MIT",
 	"repository": "josephdadams/midi-relay",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"start": "electron .",
 		"pack": "electron-builder --dir",
 		"dist": "electron-builder --macos --linux --windows",
+		"distWin": "electron-builder --windows",
 		"release": "np"
 	},
 	"dependencies": {

--- a/static/index.css
+++ b/static/index.css
@@ -37,7 +37,7 @@
 	align-items: center;
 	z-index: 100;
 	position: fixed;
-	right: 25px;
+	right: 7%;
 	top: 30px;
   }
   
@@ -56,9 +56,9 @@
   
   .theme-switch {
 	display: inline-block;
-	height: 34px;
+	height: 10px;
 	position: relative;
-	width: 60px;
+	width: 48px;
   }
   
   .theme-switch input {
@@ -110,6 +110,14 @@
 
   #container {
 	display: flex;
+	width: 600px;
+	margin: 20px auto;
+	padding: 20px;
+	display: block;
+
+	#titleText {
+	text-align: center;
+	}
 
 }
 
@@ -119,27 +127,89 @@
 }
 
 #divMIDIPortsContainer {
-	width: 200x;
+	width: 200px;
 	padding: 5px;
 	float: left;
 	margin: 5px;
 }
 
+#triggersTable{
+	margin: 0 auto;
+	border-collapse: collapse;
+}
+
+#triggersTable td{
+	border-top: #999999 3px solid;
+	border-bottom: #999999 3px solid;
+	padding: 5px;
+}
+
 #divTriggersContainer {
-	width: 200x;
+	width: 600px;
 	padding: 5px;
 	float: left;
 	margin: 5px;
 }
 
 #divImportExportContainer {
-	width: 200px;
+	width: 600px;
 	height: auto;
 	padding: 5px;
 	float: left;
 	margin: 5px;
 }
 
-.borderTop {
-	border-top: #999999 3px solid;
+/* Style inputs, select elements and textareas */
+input[type=text], [type=file], select, textarea {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  resize: vertical;
+}
+
+/* Style the label to display next to the inputs */
+label {
+  padding: 12px 12px 12px 0;
+  display: inline-block;
+}
+
+/* Style the submit button */
+button {
+  background-color: #04AA6D;
+  color: white;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+/* Floating column for labels: 25% width */
+.col-40 {
+  float: left;
+  width: 40%;
+  margin-top: 6px;
+}
+
+/* Floating column for inputs: 75% width */
+.col-60 {
+  float: left;
+  width: 60%;
+  margin-top: 6px;
+}
+
+/* Clear floats after the columns */
+.row:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+/* Responsive layout - when the screen is less than 600px wide, make the two columns stack on top of each other instead of next to each other */
+@media screen and (max-width: 600px) {
+  .col-25, .col-75, input[type=submit] {
+    width: 100%;
+    margin-top: 0;
+  }
 }

--- a/static/index.css
+++ b/static/index.css
@@ -185,17 +185,31 @@ button {
   cursor: pointer;
 }
 
-/* Floating column for labels: 25% width */
+/* Floating column for labels: 40% width */
 .col-40 {
   float: left;
   width: 40%;
   margin-top: 6px;
 }
 
-/* Floating column for inputs: 75% width */
+/* Floating column for inputs: 60% width */
 .col-60 {
   float: left;
   width: 60%;
+  margin-top: 6px;
+}
+
+/* Floating column for inputs: 80% width */
+.col-80 {
+  float: left;
+  width: 80%;
+  margin-top: 6px;
+}
+
+/* Floating column for inputs: 20% width */
+.col-20 {
+  float: left;
+  width: 20%;
   margin-top: 6px;
 }
 
@@ -212,4 +226,65 @@ button {
     width: 100%;
     margin-top: 0;
   }
+}
+
+#bitfocusCompanionInfo {
+	margin: 10px;
+}
+
+pre {
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	border: 1px solid;
+	margin: 10px;
+	padding: 10px;
+	padding-right: 30px;
+	cursor: pointer;
+}
+
+/* Style the buttons that are used to open and close the accordion panel */
+.accordion {
+  background-color: #00e8f3;
+  color: #414141;
+  cursor: pointer;
+  padding: 18px;
+  width: 100%;
+  text-align: left;
+	font-weight: 600;
+  border: none;
+  outline: none;
+	border-radius: 0px;
+  transition: 0.4s;
+}
+
+/* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */
+.active, .accordion:hover {
+  background-color: #00e8f3;
+}
+
+/* Style the accordion panel. Note: hidden by default */
+.panel {
+  padding: 0 18px;
+  background-color: #00e8f3;
+	border: 1px solid #00e8f3;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.2s ease-out;
+}
+
+.accordion:after {
+  content: '\02795'; /* Unicode character for "plus" sign (+) */
+  font-size: 13px;
+  color: #777;
+  float: right;
+  margin-left: 5px;
+}
+
+.active:after {
+  content: "\2796"; /* Unicode character for "minus" sign (-) */
+}
+
+.clipboardText {
+	align-items: center;
+	display: flex;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,6 @@
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/all.min.css" />
 		<link rel="stylesheet" href="index.css">
 		<script src="/socket.io/socket.io.js"></script>
-		<script src="https://kit.fontawesome.com/2b7f9c8b37.js" crossorigin="anonymous"></script>
 	</head>
 	<body onLoad="onLoad();">
 		<div id="container">
@@ -144,6 +143,44 @@
 						</div>
 					</div>
 					<div id='divMIDIMessage_ActionType_HTTP' style='display:none;'>
+						<div class="row" id="bitfocusCompanionInfo">
+							<button class="accordion" id="bitfocusCompanionHelpers" onclick="showHideAccordion()">BitFocus Companion Helpers</button>
+							<div class="panel" id="bitfocusCompanionInfoPanel">
+								<p>For Call Bitfocus Companion Button Function, use rules below:</p>
+								<ul>
+									<li>Enable Bitfocus Companion HTTP API in Settings -> HTTP API</li>
+									<li>Available Action (action) Button Value:
+										<ul>
+											<li>press - Press and release a button (run both down and up actions)</li>
+											<li>down - Press the button (run down actions and hold)</li>
+											<li>up - Release the button (run up actions)</li>
+											<li>rotate-left - Trigger a left rotation of the button/encoder</li>
+											<li>rotate-right - Trigger a right rotation of the button/encoder</li>
+										</ul>
+									</li>
+									<li>Fill URL with : 
+										<div class="row clipboardText">
+											<div class="col-80">
+												<pre id="copyCompanionUrl" onclick="copyToClipboard('copyCompanionUrl')">http://(companionIP:companionPort)/api/location/(page)/(row)/(column)/(action)</pre>
+											</div>
+											<div class="col-20">
+												<button class="copyButton" onclick="copyToClipboard('copyCompanionUrl')">Copy</button>
+											</div>
+										</div>
+									</li>
+									<li>Fill JSON Data with dummy JSON
+										<div class="row clipboardText">
+											<div class="col-80">
+												<pre id="copyJsonData" onclick="copyToClipboard('copyJsonData')">{"hello":"hello"}</pre>
+											</div>
+											<div class="col-20">
+												<button class="copyButton" onclick="copyToClipboard('copyJsonData')">Copy</button>
+											</div>
+										</div>
+									</li>
+								</ul>
+							</div>
+						</div>
 						<div class="row">
 							<div class="col-40">
 								<label for="txtURL">URL:</label>
@@ -195,8 +232,10 @@
 					<button id='btnAddTrigger' onclick='AddTrigger();'>Add Trigger</button>
 					<button id='btnEditTrigger' onclick='EditTrigger();'>Edit Trigger</button>
 					<button id='btnCancel' onclick='Cancel();' style="display:inline-block">Cancel</button>
+					<br/>
 				</div>	
 			</div>
+			<br/>
 			<hr>
 			<div id='divImportExportContainer'>
 				<h4>Import/Export Data:</h4>

--- a/static/index.html
+++ b/static/index.html
@@ -2,6 +2,7 @@
 <html>
 	<head>
 		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>midi-relay</title>
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/all.min.css" />
 		<link rel="stylesheet" href="index.css">
@@ -10,6 +11,9 @@
 	</head>
 	<body onLoad="onLoad();">
 		<div id="container">
+			<div id="titleText">
+				<h2>MIDI-Relay Triggers Editor</h2>
+			</div>
 			<div class="theme-switch-wrapper">
 				<!-- Text and icon -->
 				<span id="toggle-icon">
@@ -23,62 +27,188 @@
 				</label>
 			</div>
 			<div id='divTriggersContainer'>
-				<b>Triggers:</b><br /><br />
+				<h4>Triggers:</h4>
 				<div id='divTriggers'></div>
-				<br /><button id='btnShowAddTrigger' onclick='ShowAddTrigger();'>Add New MIDI Trigger</button><br /><br />
+				<br/>
+				<button id='btnShowAddTrigger' onclick='ShowAddTrigger();'>Add New MIDI Trigger</button><br /><br />
 				<div id='divTriggerFields' style='display:none;'>
-					MIDI Input Port:
-					<select id='selectMIDIPort'></select><br />
-					Incoming MIDI Message Type:
-					<select id='selectMIDIMessageType' onchange='showMIDIMessageOptions();'>
-						<option value='0'>(Choose a Type)</option>
-						<option value='noteon'>Note On</option>
-						<option value='noteoff'>Note Off</option>
-						<option value='aftertouch'>Polyphonic Aftertouch</option>
-						<option value='cc'>Control Change</option>
-						<option value='pc'>Program Change</option>
-						<option value='pressure'>Channel Pressure / Aftertouch</option>
-						<option value='pitchbend'>Pitch Bend / Pitch Wheel</option>
-						<option value='sysex'>SysEx</option>
-					</select><br />
+					<div class="row">
+						<div class="col-40">
+							<label for="selectMIDIPort">MIDI Input Port:</label>
+						</div>
+						<div class="col-60">
+							<select id='selectMIDIPort'></select>						
+						</div>
+					</div>
+					<div class="row">
+						<div class="col-40">
+							<label for="selectMIDIMessageType">Incoming MIDI Message Type:</label>
+						</div>
+						<div class="col-60">
+							<select id='selectMIDIMessageType' onchange='showMIDIMessageOptions();'>
+								<option value='0'>(Choose a Type)</option>
+								<option value='noteon'>Note On</option>
+								<option value='noteoff'>Note Off</option>
+								<option value='aftertouch'>Polyphonic Aftertouch</option>
+								<option value='cc'>Control Change</option>
+								<option value='pc'>Program Change</option>
+								<option value='pressure'>Channel Pressure / Aftertouch</option>
+								<option value='pitchbend'>Pitch Bend / Pitch Wheel</option>
+								<option value='sysex'>SysEx</option>
+							</select>
+						</div>
+					</div>					
 					<div id='divMIDIMessage_Options'>
-						<div id='divMIDIMessage_Options_Channel' style='display:none;'>Channel: <select id='selectMIDIChannel'></select></div>
-						<div id='divMIDIMessage_Options_Note' style='display:none;'>Note: <select id='selectMIDINote'></select></div>
-						<div id='divMIDIMessage_Options_Velocity' style='display:none;'>Velocity: <select id='selectMIDIVelocity'></select></div>
-						<div id='divMIDIMessage_Options_Controller' style='display:none;'>Controller: <select id='selectMIDIController'></select></div>
-						<div id='divMIDIMessage_Options_Value' style='display:none;'>Value: <select id='selectMIDIValue'></select></div>
-						<div id='divMIDIMessage_Options_PitchBend_Value' style='display:none;'>Value (between 0 and 16383): <input type='text' id='inputMIDIPitchBendValue' value='8192' width='50' /></div>
-						<div id='divMIDIMessage_Options_SysExMessage' style='display:none;'>SysEx Message: <input type='text' id='inputMIDISysExMessage' width='50' /></div>
+						<div id='divMIDIMessage_Options_Channel' style='display:none;'>
+							<div class="row">
+								<div class="col-40">
+									<label for="selectMIDIChannel">Channel:</label>
+								</div>
+								<div class="col-60">
+									<select id='selectMIDIChannel'></select>						
+								</div>
+							</div>
+						</div>
+						<div id='divMIDIMessage_Options_Note' style='display:none;'>
+							<div class="row">
+								<div class="col-40">
+									<label for="selectMIDINote">Note:</label>
+								</div>
+								<div class="col-60">
+									<select id='selectMIDINote'></select>						
+								</div>
+							</div>
+						</div>
+						<div id='divMIDIMessage_Options_Velocity' style='display:none;'>
+							<div class="row">
+								<div class="col-40">
+									<label for="selectMIDIVelocity">Velocity:</label>
+								</div>
+								<div class="col-60">
+									<select id='selectMIDIVelocity'></select>						
+								</div>
+							</div>
+						</div>
+						<div id='divMIDIMessage_Options_Controller' style='display:none;'>
+							<div class="row">
+								<div class="col-40">
+									<label for="selectMIDIController">Controller:</label>
+								</div>
+								<div class="col-60">
+									<select id='selectMIDIController'></select>						
+								</div>
+							</div>
+						</div>
+						<div id='divMIDIMessage_Options_Value' style='display:none;'>
+							<div class="row">
+								<div class="col-40">
+									<label for="selectMIDIValue">Value:</label>
+								</div>
+								<div class="col-60">
+									<select id='selectMIDIValue'></select>						
+								</div>
+							</div>
+						</div>
+						<div id='divMIDIMessage_Options_PitchBend_Value' style='display:none;'>
+							<div class="row">
+								<div class="col-40">
+									<label for="inputMIDIPitchBendValue">Value (between 0 and 16383):</label>
+								</div>
+								<div class="col-60">
+									<input type='text' id='inputMIDIPitchBendValue' value='8192' width='50' />				
+								</div>
+							</div>
+						</div>
+						<div id='divMIDIMessage_Options_SysExMessage' style='display:none;'>
+							<div class="row">
+								<div class="col-40">
+									<label for="inputMIDISysExMessage">SysEx Message:</label>
+								</div>
+								<div class="col-60">
+									<input type='text' id='inputMIDISysExMessage' width='50' />					
+								</div>
+							</div>
+						</div>
 					</div>
 					<div id='divMIDIMessage_ActionType' onchange='showActionTypeOptions();'>
-						Action Type:
-						<select id='selectActionType'>
-							<option value='0'>(Choose a Type)</option>
-							<option value='http'>HTTP GET/POST</option>
-						</select>
+						<div class="row">
+							<div class="col-40">
+								<label for="selectActionType">Action Type:</label>
+							</div>
+							<div class="col-60">
+								<select id='selectActionType'>
+									<option value='0'>(Choose a Type)</option>
+									<option value='http'>HTTP GET/POST</option>
+								</select>
+							</div>
+						</div>
 					</div>
 					<div id='divMIDIMessage_ActionType_HTTP' style='display:none;'>
-						URL: <input type='text' id='txtURL' value='http://' /><br />
-						JSON Data: <textarea rows='5' cols='40' id='txtJSONData'></textarea>
+						<div class="row">
+							<div class="col-40">
+								<label for="txtURL">URL:</label>
+							</div>
+							<div class="col-60">
+								<input type='text' id='txtURL' value='http://' />
+							</div>
+						</div>
+						<div class="row">
+							<div class="col-40">
+								<label for="txtJSONData">JSON Data:</label>
+							</div>
+							<div class="col-60">
+								<textarea rows='5' cols='40' id='txtJSONData'></textarea>
+							</div>
+						</div>
 					</div>
 					<div id='divMIDIMessage_ActionType_AppleScript' style='display:none;'>
-						AppleScript: <textarea rows='5' cols='40' id='txtAppleScript'></textarea>
+						<div class="row">
+							<div class="col-40">
+								<label for="txtAppleScript">AppleScript:</label>
+							</div>
+							<div class="col-60">
+								<textarea rows='5' cols='40' id='txtAppleScript'></textarea>
+							</div>
+						</div>
 					</div>
 					<div id='divMIDIMessage_ActionType_ShellScript' style='display:none;'>
-						Shell Script: <textarea rows='5' cols='40' id='txtShellScript'></textarea>
+						<div class="row">
+							<div class="col-40">
+								<label for="txtShellScript">Shell Script:</label>
+							</div>
+							<div class="col-60">
+								<textarea rows='5' cols='40' id='txtShellScript'></textarea>
+							</div>
+						</div>
 					</div>
 					<div id='divMIDIMessage_Description'>
-						Description: <textarea rows='5' cols='40' id='txtDescription'></textarea>
+						<div class="row">
+							<div class="col-40">
+								<label for="txtDescription">Description:</label>
+							</div>
+							<div class="col-60">
+								<textarea rows='5' cols='40' id='txtDescription'></textarea>
+							</div>
+						</div>
 					</div>
+					<br/>
 					<button id='btnAddTrigger' onclick='AddTrigger();'>Add Trigger</button>
 					<button id='btnEditTrigger' onclick='EditTrigger();'>Edit Trigger</button>
-					<button id='btnCancel' onclick='Cancel();'>Cancel</button>
+					<button id='btnCancel' onclick='Cancel();' style="display:inline-block">Cancel</button>
 				</div>	
 			</div>
+			<hr>
 			<div id='divImportExportContainer'>
-				<b>Import/Export Data:</b><br />
+				<h4>Import/Export Data:</h4>
 				<button id='btnExport_Triggers' onclick='export_triggers();'>Export Triggers</button><br /><br />
-				<input type='file' id='flImport' />
+				<div class="row">
+					<div class="col-40">
+						<label for="flImport">Triggers Settings File:</label>
+					</div>
+					<div class="col-60">
+						<input type='file' id='flImport' />
+					</div>
+				</div>
 				<button id='btnImport_Triggers' onclick='import_triggers();'>Import Triggers</button>
 			</div>
 		</div>

--- a/static/index.html
+++ b/static/index.html
@@ -31,7 +31,7 @@
 					<select id='selectMIDIPort'></select><br />
 					Incoming MIDI Message Type:
 					<select id='selectMIDIMessageType' onchange='showMIDIMessageOptions();'>
-						<option value='0'>(choose a type)</option>
+						<option value='0'>(Choose a Type)</option>
 						<option value='noteon'>Note On</option>
 						<option value='noteoff'>Note Off</option>
 						<option value='aftertouch'>Polyphonic Aftertouch</option>
@@ -53,7 +53,7 @@
 					<div id='divMIDIMessage_ActionType' onchange='showActionTypeOptions();'>
 						Action Type:
 						<select id='selectActionType'>
-							<option value='0'>(choose a type)</option>
+							<option value='0'>(Choose a Type)</option>
 							<option value='http'>HTTP GET/POST</option>
 						</select>
 					</div>

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -1300,6 +1300,28 @@ function formReset() {
 	document.getElementById('txtAppleScript').value = "";
 	document.getElementById('txtShellScript').value = "";
 	document.getElementById('txtDescription').value = "";
+	document.getElementById('bitfocusCompanionInfoPanel').style.maxHeight = null
 
 	showActionTypeOptions();
+}
+
+function showHideAccordion () {
+	const el = document.getElementById("bitfocusCompanionHelpers")
+	el.classList.toggle("active");
+	const panel = el.nextElementSibling;
+	if (panel.style.maxHeight) {
+		panel.style.maxHeight = null;
+	} else {
+		panel.style.maxHeight = panel.scrollHeight + "px";
+	}
+}
+
+function copyToClipboard (el) {
+	const text = document.getElementById(el).innerHTML;
+	if (navigator.clipboard) {
+		navigator.clipboard.writeText(text);
+		alert (`Text Copied: ${text}`);
+	} else {
+		alert('Cannot Copy Text')
+	}
 }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -84,6 +84,7 @@ function onLoad() {
 		let divTriggers = document.getElementById('divTriggers');
 	
 		let tableTriggers = document.createElement('table');
+		tableTriggers.setAttribute("id", "triggersTable")
 
 		divTriggers.innerHTML = '';
 		
@@ -100,6 +101,10 @@ function onLoad() {
 		let tdHeaderMIDIDescription = document.createElement('td');
 		tdHeaderMIDIDescription.innerHTML = '<b>Description</b>';
 		trHeader.appendChild(tdHeaderMIDIDescription);
+		let tdHeaderEditButton = document.createElement('td');
+		trHeader.appendChild(tdHeaderEditButton);
+		let tdHeaderDeleteButton = document.createElement('td');
+		trHeader.appendChild(tdHeaderDeleteButton);
 		
 		tableTriggers.appendChild(trHeader);
 
@@ -619,6 +624,7 @@ function DeleteTrigger(triggerID) {
 }
 			
 function ShowAddTrigger() {
+	formReset();
 	let btnShowAddTrigger = document.getElementById('btnShowAddTrigger');
 	btnShowAddTrigger.style.display = 'none';
 	
@@ -626,7 +632,7 @@ function ShowAddTrigger() {
 	divTriggerFields.style.display = 'block';
 
 	let btnAddTrigger = document.getElementById('btnAddTrigger');
-	btnAddTrigger.style.display = 'block';
+	btnAddTrigger.style.display = 'inline-block';
 
 	let btnEditTrigger = document.getElementById('btnEditTrigger');
 	btnEditTrigger.style.display = 'none';
@@ -812,7 +818,7 @@ function ShowEditTrigger(id) {
 	btnAddTrigger.style.display = 'none';
 
 	let btnEditTrigger = document.getElementById('btnEditTrigger');
-	btnEditTrigger.style.display = 'block';
+	btnEditTrigger.style.display = 'inline-block';
 }
 
 function showMIDIMessageOptions() {
@@ -1263,4 +1269,37 @@ function import_triggers() {
 			alert('No file or invalid file selected.');
 		}
 	}
+}
+
+function formReset() {
+	let selectMIDIPort = document.getElementById('selectMIDIPort');
+	let selectMIDIMessageType = document.getElementById('selectMIDIMessageType');
+	let selectMIDIChannel = document.getElementById('selectMIDIChannel');
+	let selectMIDINote = document.getElementById('selectMIDINote');
+	let selectMIDIVelocity = document.getElementById('selectMIDIVelocity');
+	let selectMIDIValue = document.getElementById('selectMIDIValue');
+	let selectMIDIController = document.getElementById('selectMIDIController');
+	let inputMIDIPitchBendValue = document.getElementById('inputMIDIPitchBendValue');
+	let inputMIDISysExMessage = document.getElementById('inputMIDISysExMessage');
+
+	let selectActionType = document.getElementById('selectActionType');
+
+	selectMIDIPort.options[0].selected = true;
+	selectMIDIMessageType.options[0].selected = true;
+	showMIDIMessageOptions();
+	selectMIDIChannel.options[0].selected = true;
+	selectMIDINote.options[0].selected = true;
+	selectMIDIVelocity.options[0].selected = true;
+	selectMIDIController.options[0].selected = true;
+	selectMIDIValue.options[0].selected = true;
+	inputMIDIPitchBendValue.value = "";
+	inputMIDISysExMessage.value = "";
+	selectActionType.options[0].selected = true;
+	document.getElementById('txtURL').value = "http://";		
+	document.getElementById('txtJSONData').value = "";		
+	document.getElementById('txtAppleScript').value = "";
+	document.getElementById('txtShellScript').value = "";
+	document.getElementById('txtDescription').value = "";
+
+	showActionTypeOptions();
 }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -4,6 +4,8 @@ const toggleIcon = document.getElementById('toggle-icon');
 const DARK_THEME = 'dark';
 const LIGHT_THEME = 'light';
 
+let availableTriggers = [];
+
 function toggleDarkLightMode(mode) {
  	// Change icon
   mode === DARK_THEME
@@ -62,6 +64,11 @@ function onLoad() {
 		 // using the function:
 		 removeOptions(selectMIDIPort);
 
+		let el = document.createElement('option');
+		el.textContent = '(Choose a Type)';
+		el.value = "";
+		selectMIDIPort.appendChild(el);
+
 		for (let i = 0; i < data.length; i++)
 		{	
 			let opt = data[i];
@@ -73,6 +80,7 @@ function onLoad() {
 	});
 
 	socket.on('triggers', function(triggers) {
+		availableTriggers = triggers;
 		let divTriggers = document.getElementById('divTriggers');
 	
 		let tableTriggers = document.createElement('table');
@@ -615,7 +623,7 @@ function ShowAddTrigger() {
 
 function ShowEditTrigger(id) {
 	selectedTriggerId = id;
-
+	triggers = availableTriggers;
 	for (let i = 0; i < triggers.length; i++) {
 		if (triggers[i].id === id) {
 			let selectMIDIPort = document.getElementById('selectMIDIPort');
@@ -630,6 +638,7 @@ function ShowEditTrigger(id) {
 
 			let selectActionType = document.getElementById('selectActionType');
 
+			selectMIDIPort.options[0].selected = true;
 			for (let j = 0; j < selectMIDIPort.options.length; j++){
 				if (selectMIDIPort.options[j].value === triggers[i].midiport){
 					selectMIDIPort.options[j].selected = true;

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -103,6 +103,17 @@ function onLoad() {
 		
 		tableTriggers.appendChild(trHeader);
 
+		if (!triggers.length) {
+			let trTrigger = document.createElement('tr');
+			let td = document.createElement('td');
+			td.setAttribute("colspan", 4)
+			td.setAttribute("align", "center")
+			td.innerHTML = 'No Triggers Available';
+			td.className = 'borderTop';
+			trTrigger.appendChild(td);
+			tableTriggers.appendChild(trTrigger);
+		}
+
 		for (let i = 0; i < triggers.length; i++)
 		{
 			let trTrigger = document.createElement('tr');


### PR DESCRIPTION
Hello, i'm fork midi-relay, and make some update to fit my requirement to use this MIDI-relay to forward command from ProPresenter Macro to Bitfocus Companion.

Here is some major improvement:
1. Add Context Menu to Open Triggers Settings page, so I can easily update and see the triggers setting
2. Fix Edit Triggers not populate the record to the Edit Form
3. Add some cosmetic css and functionality to Triggers Setting Page
4. Add some helpers info for calling Bitfocus Companion Http API, make it easier to add/edit Triggers
5. Because I'm using Windows and i need to build dist so I add scripts to package.json to electron-builder --windows

Full change can see in the change. 

Hope you can check and review this pull.

Thanks.